### PR TITLE
Fix modeToNum in utils

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -126,3 +126,23 @@ describe('getOrderOfEvent', () => {
     expect(index).toEqual(2)
   })
 })
+
+describe('modeToNum', () => {
+  test('3days', () => {
+    const mode = '3days'
+    const num = utils.modeToNum(mode)
+    expect(num).toEqual(3)
+  })
+
+  test('week', () => {
+    const mode = 'week'
+    const num = utils.modeToNum(mode)
+    expect(num).toEqual(7)
+  })
+
+  test('day', () => {
+    const mode = 'day'
+    const num = utils.modeToNum(mode)
+    expect(num).toEqual(1)
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -84,6 +84,8 @@ export function modeToNum(mode: Mode) {
       return 3
     case 'week':
       return 7
+    case 'day':
+      return 1
     default:
       throw new Error('undefined mode')
   }


### PR DESCRIPTION
Missing `day` support in function `modeToNum`. Will cause error swipe in day mode.
Added simple test case for function `modeToNum` also.