### PR TITLE
WIP: Add custom renderer for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ interface CalendarProps<T = {}> {
 
 | name                  | required | type                                                                                | description                                                                                                                                                                                                          |
 | --------------------- | -------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `events`              | yes      | `Array<{ title: string, start: Date, end: Date, children?: React.ReactNode }>`      | The events which will be rendered on the calendar, with optional children to display custom components on the event. Events that occur during the same time range will be layered, offset, and given a unique color. |
+| `events`              | yes      | `Array<{ title: string, start: Date, end: Date, children?: React.ReactNode, eventRenderer?: (event: DayJSConvertedEvent, touchableOpacityProps: any) => JSX.Element }>`      | The events which will be rendered on the calendar, with optional children to display custom components inside the event, and optional event renderer function to take complete control over the rendered event (advanced feature). Events that occur during the same time range will be layered, offset, and given a unique color. |
 | `height`              | yes      | `number`                                                                            | Calendar height.                                                                                                                                                                                                     |
 | `hideNowIndicator`    | no       | `boolean`                                                                           | Hides the indicator for the current time. By default the now indicator is shown.                                                                                                                                     |
 | `onPressEvent`        | no       | `(event: { title: string, start: Date, end: Date } => void)`                        | Event handler which will be fired when the user clicks an event.                                                                                                                                                     |
@@ -103,8 +103,39 @@ interface CalendarProps<T = {}> {
 | `locale`              | no       | `string`                                                                            | Custom locale. See I18n section                                                                                                                                                                                      |
 | `overlapOffset`       | no       | `number`                                                                            | Adjusts the indentation of events that occur during the same time period. Defaults to 20 on web and 8 on mobile.                                                                                                     |
 | `isRTL`               | no       | `boolean`                                                                           | Switches the direction of the layout for use with RTL languages. Defaults to false.                                                                                                                                  |
+                                                       |
 
 For more information, see [Storybook](https://github.com/llotheo/react-native-big-calendar/blob/master/stories/index.stories.tsx)
+
+## Overriding the component which renders an event
+
+You can override the component which renders a specific event. You choose to do so for all your events, or a specific event. The function `eventRenderer` must return a `JSX.Element`. The component *should* be wrapped inside a `TouchableOpacity` if you are using `react-native`, or *any* DOM element which accepts positionning and click events (`onPress`, ...). You can read more on this feature on its [PR](https://github.com/acro5piano/react-native-big-calendar/pull/359).
+
+```typescript
+
+const AgendaWithACustomRenderer: React.FC = () => {
+
+  const eventRenderer = (event: DayJSConvertedEvent, touchableOpacityProps: any) => (
+    <TouchableOpacity {...touchableOpacityProps}>
+      <Text>{`My custom event: ${event.title}`}</Text>
+    </TouchableOpacity>
+    )
+
+  return (
+    <Calendar
+      events={[
+        {
+          title: 'Custom Component',
+          start: dayjs().add(1, 'day').set('hour', 12).set('minute', 0).toDate(),
+          end: dayjs().add(1, 'day').set('hour', 15).set('minute', 30).toDate(),
+          eventRenderer,
+        },
+      ]}
+      {/* ... */}
+    />
+  )
+}
+```
 
 # I18n
 

--- a/src/CalendarEvent.tsx
+++ b/src/CalendarEvent.tsx
@@ -58,21 +58,20 @@ export function _CalendarEvent({
     onPressEvent && onPressEvent(plainJsEvent)
   }, [onPressEvent, plainJsEvent])
 
+  const touchableOpacityProps = {
+    delayPressIn: 20,
+    key: event.start.toString(),
+    style: [
+      commonStyles.eventCell,
+      getEventCellPositionStyle(event),
+      getStyleForOverlappingEvent(eventCount, eventOrder, overlapOffset),
+      getEventStyle(plainJsEvent),
+    ],
+    onPress: _onPress,
+    disabled: !onPressEvent,
+  }
 
-const touchableOpacityProps = {
-  delayPressIn:20,
-      key:event.start.toString(),
-      style:[
-        commonStyles.eventCell,
-        getEventCellPositionStyle(event),
-        getStyleForOverlappingEvent(eventCount, eventOrder, overlapOffset),
-        getEventStyle(plainJsEvent),
-      ],
-      onPress:_onPress,
-      disabled:!onPressEvent,
-}
-
-  if(event.eventRenderer){
+  if (event.eventRenderer) {
     return event.eventRenderer(event, touchableOpacityProps)
   }
 

--- a/src/CalendarEvent.tsx
+++ b/src/CalendarEvent.tsx
@@ -58,19 +58,26 @@ export function _CalendarEvent({
     onPressEvent && onPressEvent(plainJsEvent)
   }, [onPressEvent, plainJsEvent])
 
-  return (
-    <TouchableOpacity
-      delayPressIn={20}
-      key={event.start.toString()}
-      style={[
+
+const touchableOpacityProps = {
+  delayPressIn:20,
+      key:event.start.toString(),
+      style:[
         commonStyles.eventCell,
         getEventCellPositionStyle(event),
         getStyleForOverlappingEvent(eventCount, eventOrder, overlapOffset),
         getEventStyle(plainJsEvent),
-      ]}
-      onPress={_onPress}
-      disabled={!onPressEvent}
-    >
+      ],
+      onPress:_onPress,
+      disabled:!onPressEvent,
+}
+
+  if(event.eventRenderer){
+    return event.eventRenderer(event, touchableOpacityProps)
+  }
+
+  return (
+    <TouchableOpacity {...touchableOpacityProps}>
       {event.end.diff(event.start, 'minute') < 32 && showTime ? (
         <Text style={commonStyles.eventTitle}>
           {event.title},<Text style={styles.eventTime}>{event.start.format('HH:mm')}</Text>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,12 +6,14 @@ export interface BaseEvent {
   start: Date
   end: Date
   title: string
+  eventRenderer?: (event: DayJSConvertedEvent, touchableOpacityProps: any) => JSX.Element 
 }
 
 export interface DayJSConvertedEvent {
   start: dayjs.Dayjs
   end: dayjs.Dayjs
   title: string
+  eventRenderer?: (event: DayJSConvertedEvent, touchableOpacityProps: any) => JSX.Element 
   children?: React.ReactNode
 }
 

--- a/stories/desktop.stories.tsx
+++ b/stories/desktop.stories.tsx
@@ -1,11 +1,12 @@
 import { storiesOf } from '@storybook/react'
 import dayjs from 'dayjs'
 import React from 'react'
-import { Alert, Dimensions, View } from 'react-native'
+import { Alert, Dimensions, View, Text } from 'react-native'
 import { Calendar } from '../src/Calendar'
 import { Control, CONTROL_HEIGHT } from './components/Control'
-import { events } from './events'
+import { customRendererEvents, events } from './events'
 import { styles } from './styles'
+
 
 function alert(input: any) {
   // @ts-ignore
@@ -177,6 +178,20 @@ storiesOf('Desktop', module)
           height={SCREEN_HEIGHT}
           events={events}
           isRTL={true}
+        />
+      </View>
+    )
+  })
+  .add('Custom Event Component renderer', () => {
+    
+    return (
+      <View style={styles.desktop}>
+        <Calendar
+          style={styles.calendar}
+          height={SCREEN_HEIGHT}
+          events={[...events, ...customRendererEvents]}
+
+
         />
       </View>
     )

--- a/stories/desktop.stories.tsx
+++ b/stories/desktop.stories.tsx
@@ -7,7 +7,6 @@ import { Control, CONTROL_HEIGHT } from './components/Control'
 import { customRendererEvents, events } from './events'
 import { styles } from './styles'
 
-
 function alert(input: any) {
   // @ts-ignore
   if (typeof window !== 'undefined') {
@@ -183,15 +182,12 @@ storiesOf('Desktop', module)
     )
   })
   .add('Custom Event Component renderer', () => {
-    
     return (
       <View style={styles.desktop}>
         <Calendar
           style={styles.calendar}
           height={SCREEN_HEIGHT}
           events={[...events, ...customRendererEvents]}
-
-
         />
       </View>
     )

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -13,7 +13,6 @@ const eventNotes = (
   </View>
 )
 
-
 export const events = [
   {
     title: 'Watch Boxing',
@@ -54,49 +53,54 @@ export const events = [
 ]
 
 const eventRenderer = (event: DayJSConvertedEvent, touchableOpacityProps: any) => {
-  console.log({ style:touchableOpacityProps.style })
-  return <TouchableOpacity {...touchableOpacityProps} 
-    style={[
-      ...touchableOpacityProps.style, 
-      { 
-        backgroundColor: 'white', 
-        borderWidth: 1,
-        borderColor: 'lightgrey',
-        borderLeftColor: event.color ? event.color : touchableOpacityProps.style[2].backgroundColor, 
-        borderLeftWidth: 10, 
-        borderStyle: 'solid', 
-        borderRadius: 6, 
-        alignItems: 'center', 
-        justifyContent: 'center' 
-      }
-      ]}>
-    {event.end.diff(event.start, 'minute') < 32 && showTime ? (
-        <Text style={{...commonStyles.eventTitle, color: 'black'}}>
+  return (
+    <TouchableOpacity
+      {...touchableOpacityProps}
+      style={[
+        ...touchableOpacityProps.style,
+        {
+          backgroundColor: 'white',
+          borderWidth: 1,
+          borderColor: 'lightgrey',
+          borderLeftColor: event.color
+            ? event.color
+            : touchableOpacityProps.style[2].backgroundColor,
+          borderLeftWidth: 10,
+          borderStyle: 'solid',
+          borderRadius: 6,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+      ]}
+    >
+      {event.end.diff(event.start, 'minute') < 32 && showTime ? (
+        <Text style={{ ...commonStyles.eventTitle, color: 'black' }}>
           {event.title},<Text style={styles.eventTime}>{event.start.format('HH:mm')}</Text>
         </Text>
       ) : (
         <>
-          <Text style={{...commonStyles.eventTitle, color: 'black'}}>{event.title}</Text>
+          <Text style={{ ...commonStyles.eventTitle, color: 'black' }}>{event.title}</Text>
           <Text style={styles.eventTime}>{formatStartEnd(event)}</Text>
           {event.children && event.children}
         </>
       )}
-  </TouchableOpacity>}
+    </TouchableOpacity>
+  )
+}
 
-export const customRendererEvents =   [
+export const customRendererEvents = [
   {
-  title: "Custom Renderer",
-  start: dayjs().add(1, 'day').set('hour', 12).set('minute', 0).toDate(),
-  end: dayjs().add(1, 'day').set('hour', 15).set('minute', 30).toDate(),
-  // color: 'green',
-  eventRenderer
-},
-{
-  title: "Custom reminder",
-  start: dayjs().set('hour', 16).set('minute', 0).toDate(),
-  end: dayjs().set('hour', 17).set('minute', 0).toDate(),
-  color: 'purple',
-  eventRenderer
-},
-
+    title: 'Custom Renderer',
+    start: dayjs().add(1, 'day').set('hour', 12).set('minute', 0).toDate(),
+    end: dayjs().add(1, 'day').set('hour', 15).set('minute', 30).toDate(),
+    // color: 'green',
+    eventRenderer,
+  },
+  {
+    title: 'Custom reminder',
+    start: dayjs().set('hour', 16).set('minute', 0).toDate(),
+    end: dayjs().set('hour', 17).set('minute', 0).toDate(),
+    color: 'purple',
+    eventRenderer,
+  },
 ]

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -1,6 +1,10 @@
 import dayjs from 'dayjs'
 import React from 'react'
-import { Text, View } from 'react-native'
+import { Text, TouchableOpacity, View } from 'react-native'
+import { commonStyles } from '../src/commonStyles'
+import { DayJSConvertedEvent } from '../src/interfaces'
+import { formatStartEnd } from '../src/utils'
+import { styles } from './styles'
 
 const eventNotes = (
   <View style={{ marginTop: 3 }}>
@@ -8,6 +12,7 @@ const eventNotes = (
     <Text style={{ fontSize: 10, color: 'white' }}> Arrive 15 minutes early </Text>
   </View>
 )
+
 
 export const events = [
   {
@@ -46,4 +51,52 @@ export const events = [
     end: dayjs().set('hour', 14).set('minute', 15).toDate(),
     children: eventNotes,
   },
+]
+
+const eventRenderer = (event: DayJSConvertedEvent, touchableOpacityProps: any) => {
+  console.log({ style:touchableOpacityProps.style })
+  return <TouchableOpacity {...touchableOpacityProps} 
+    style={[
+      ...touchableOpacityProps.style, 
+      { 
+        backgroundColor: 'white', 
+        borderWidth: 1,
+        borderColor: 'lightgrey',
+        borderLeftColor: event.color ? event.color : touchableOpacityProps.style[2].backgroundColor, 
+        borderLeftWidth: 10, 
+        borderStyle: 'solid', 
+        borderRadius: 6, 
+        alignItems: 'center', 
+        justifyContent: 'center' 
+      }
+      ]}>
+    {event.end.diff(event.start, 'minute') < 32 && showTime ? (
+        <Text style={{...commonStyles.eventTitle, color: 'black'}}>
+          {event.title},<Text style={styles.eventTime}>{event.start.format('HH:mm')}</Text>
+        </Text>
+      ) : (
+        <>
+          <Text style={{...commonStyles.eventTitle, color: 'black'}}>{event.title}</Text>
+          <Text style={styles.eventTime}>{formatStartEnd(event)}</Text>
+          {event.children && event.children}
+        </>
+      )}
+  </TouchableOpacity>}
+
+export const customRendererEvents =   [
+  {
+  title: "Custom Renderer",
+  start: dayjs().add(1, 'day').set('hour', 12).set('minute', 0).toDate(),
+  end: dayjs().add(1, 'day').set('hour', 15).set('minute', 30).toDate(),
+  // color: 'green',
+  eventRenderer
+},
+{
+  title: "Custom reminder",
+  start: dayjs().set('hour', 16).set('minute', 0).toDate(),
+  end: dayjs().set('hour', 17).set('minute', 0).toDate(),
+  color: 'purple',
+  eventRenderer
+},
+
 ]


### PR DESCRIPTION
This pull request adds the opportunity for a custom event renderer function.

Example use : 

```typescript
const eventRenderer = (event: DayJSConvertedEvent, touchableOpacityProps: any) => {
  return (
    <TouchableOpacity
      {...touchableOpacityProps}
      style={[
        ...touchableOpacityProps.style,
        {
          backgroundColor: 'white',
          borderWidth: 1,
          borderColor: 'lightgrey',
          borderLeftColor: event.color
            ? event.color
            : touchableOpacityProps.style[2].backgroundColor,
          borderLeftWidth: 10,
          borderStyle: 'solid',
          borderRadius: 6,
          alignItems: 'center',
          justifyContent: 'center',
        },
      ]}
    >
      {event.end.diff(event.start, 'minute') < 32 && showTime ? (
        <Text style={{ ...commonStyles.eventTitle, color: 'black' }}>
          {event.title},<Text style={styles.eventTime}>{event.start.format('HH:mm')}</Text>
        </Text>
      ) : (
        <>
          <Text style={{ ...commonStyles.eventTitle, color: 'black' }}>{event.title}</Text>
          <Text style={styles.eventTime}>{formatStartEnd(event)}</Text>
          {event.children && event.children}
        </>
      )}
    </TouchableOpacity>
  )
}

export const customRendererEvents = [
  {
    title: 'Custom Renderer',
    start: dayjs().add(1, 'day').set('hour', 12).set('minute', 0).toDate(),
    end: dayjs().add(1, 'day').set('hour', 15).set('minute', 30).toDate(),
    eventRenderer,
  },
  {
    title: 'Custom reminder',
    start: dayjs().set('hour', 16).set('minute', 0).toDate(),
    end: dayjs().set('hour', 17).set('minute', 0).toDate(),
    color: 'purple',
    eventRenderer,
  },
]
``` 
