### PR TITLE
Export CalendarProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ function App() {
 **Summary**
 
 ```typescript
-interface CalendarProps<T = {}> {
+interface CalendarProps<T> {
   events: Event<T>[]
   height: number
   hideNowIndicator?: boolean

--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -20,7 +20,7 @@ import {
   modeToNum,
 } from './utils'
 
-interface CalendarProps<T> {
+export interface CalendarProps<T> {
   events: Event<T>[]
   height: number
   overlapOffset?: number


### PR DESCRIPTION
TypeScript users might need to use this type.
Removing the default value as it's defined by its component ctor.