### PR TITLE
Fixes the issue described in #423

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export function getDatesInWeek(
   const days = Array(7)
     .fill(0)
     .map((_, i) => {
-      return subject.add(i - subjectDOW + weekStartsOn, 'day').locale(locale)
+      return subject.add(i - (subjectDOW < weekStartsOn ? 7 + subjectDOW : subjectDOW) + weekStartsOn, 'day').locale(locale)
     })
   return days
 }


### PR DESCRIPTION
Fixes the issue where the change from day to week view would display the wrong week when the startOfWeek is not the default, closes #423