### PR TITLE
Exported CalendarBody component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Calendar } from './components/Calendar'
 export * from './components/Calendar'
 export * from './components/DefaultCalendarEventRenderer'
 export * from './interfaces'
+export * from './components/CalendarBody'
 
 /* eslint-disable */
 export default Calendar


### PR DESCRIPTION
1) For one of use case we have to just use CalendarBody component. But it was not accessible as we haven't exported it. Made changes related to it. We can now just render CalendarBody component.
2) Tested locally.

Thank you