### PR TITLE
Calendar day mode without showing header component

### DIFF
--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -107,6 +107,8 @@ function _Calendar<T>({
         return getDatesInNextThreeDays(targetDate, locale)
       case 'day':
         return getDatesInNextOneDay(targetDate, locale)
+      case 'headerless':
+          return getDatesInNextOneDay(targetDate, locale)
       case 'custom':
         return getDatesInNextCustomDays(targetDate, weekStartsOn, weekEndsOn, locale)
       default:
@@ -164,6 +166,28 @@ function _Calendar<T>({
           targetDate={targetDate}
           maxVisibleEventCount={maxVisibleEventCount}
         />
+      </React.Fragment>
+    )
+  }
+
+  if (mode === 'headerless') {
+    return (
+      <React.Fragment>
+      <CalendarBody
+        {...commonProps}
+        containerHeight={height}
+        events={daytimeEvents}
+        eventCellStyle={eventCellStyle}
+        hideNowIndicator={hideNowIndicator}
+        overlapOffset={overlapOffset}
+        scrollOffsetMinutes={scrollOffsetMinutes}
+        ampm={ampm}
+        showTime={showTime}
+        onPressCell={onPressCell}
+        onPressEvent={onPressEvent}
+        onSwipeHorizontal={onSwipeHorizontal}
+        renderEvent={renderEvent}
+      />
       </React.Fragment>
     )
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,7 +18,7 @@ export type CalendarTouchableOpacityProps = {
 
 export type ICalendarEvent<T = {}> = ICalendarEventBase & T
 
-export type Mode = '3days' | 'week' | 'day' | 'custom' | 'month'
+export type Mode = '3days' | 'week' | 'day' | 'custom' | 'month' | 'headerless'
 
 export type EventCellStyle<T> = ViewStyle | ((event: ICalendarEvent<T>) => ViewStyle)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,6 +126,8 @@ export function modeToNum(mode: Mode, current?: dayjs.Dayjs): number {
       return 7
     case 'day':
       return 1
+    case 'headerless':
+        return 1
     case 'custom':
       return 7
     default:


### PR DESCRIPTION
Hello @acro5piano , So in one of our use case we needed one new calendar view which will not show calendar header. Hence we added one new view as 'headerless' which will be same as 'day' mode just without calendar header. Let me know incase of any updates. Any suggestions are welcome too.. Thank you.