### PR TITLE
Support event spanning on month mode

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,10 +1,12 @@
 import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
 import isBetween from 'dayjs/plugin/isBetween'
 import * as R from 'remeda'
 
 import * as utils from '../utils'
 
 dayjs.extend(isBetween)
+dayjs.extend(duration)
 
 const events: Event[] = [
   {
@@ -41,6 +43,11 @@ const events: Event[] = [
     title: 'Laundry',
     start: dayjs().add(1, 'day').set('hour', 8).set('minute', 25),
     end: dayjs().add(1, 'day').set('hour', 11).set('minute', 0),
+  },
+  {
+    title: 'Vacation',
+    start: dayjs().subtract(1, 'week').set('day', 3).set('hour', 8).set('minute', 25),
+    end: dayjs().add(1, 'week').set('hour', 11).set('minute', 0),
   },
 ]
 
@@ -163,5 +170,42 @@ describe('modeToNum', () => {
     const mode = 'custom'
     const num = utils.modeToNum(mode)
     expect(num).toEqual(7)
+  })
+})
+
+describe('spanning events', () => {
+  test('first day', () => {
+    const date = dayjs().subtract(1, 'week').set('day', 3)
+    const { eventWidth, isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+      events[7],
+      date,
+      date.day(),
+    )
+
+    expect(isMultipleDays).toBe(true)
+    expect(isMultipleDaysStart).toBe(true)
+  })
+  test('second day', () => {
+    const date = dayjs().subtract(1, 'week').set('day', 4)
+    const { eventWidth, isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+      events[7],
+      date,
+      date.day(),
+    )
+
+    expect(isMultipleDays).toBe(true)
+    expect(isMultipleDaysStart).toBe(false)
+  })
+  test('first day of second week', () => {
+    const date = dayjs().set('day', 0)
+
+    const { eventWidth, isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+      events[7],
+      date,
+      date.day(),
+    )
+
+    expect(isMultipleDays).toBe(true)
+    expect(isMultipleDaysStart).toBe(true)
   })
 })

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -176,7 +176,7 @@ describe('modeToNum', () => {
 describe('spanning events', () => {
   test('first day', () => {
     const date = dayjs().subtract(1, 'week').set('day', 3)
-    const { eventWidth, isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+    const { isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
       events[7],
       date,
       date.day(),
@@ -187,7 +187,7 @@ describe('spanning events', () => {
   })
   test('second day', () => {
     const date = dayjs().subtract(1, 'week').set('day', 4)
-    const { eventWidth, isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+    const { isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
       events[7],
       date,
       date.day(),
@@ -199,7 +199,7 @@ describe('spanning events', () => {
   test('first day of second week', () => {
     const date = dayjs().set('day', 0)
 
-    const { eventWidth, isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+    const { isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
       events[7],
       date,
       date.day(),

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -46,8 +46,8 @@ const events: Event[] = [
   },
   {
     title: 'Vacation',
-    start: dayjs().subtract(1, 'week').set('day', 3).set('hour', 8).set('minute', 25),
-    end: dayjs().add(1, 'week').set('hour', 11).set('minute', 0),
+    start: dayjs().add(1, 'week').set('day', 3).set('hour', 8).set('minute', 25),
+    end: dayjs().add(2, 'week').set('hour', 11).set('minute', 0),
   },
 ]
 
@@ -175,37 +175,43 @@ describe('modeToNum', () => {
 
 describe('spanning events', () => {
   test('first day', () => {
-    const date = dayjs().subtract(1, 'week').set('day', 3)
-    const { isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+    const date = dayjs().add(1, 'week').set('day', 3)
+    const { isMultipleDays, isMultipleDaysStart, eventWeekDuration } = utils.getEventSpanningInfo(
       events[7],
       date,
       date.day(),
+      0,
     )
 
     expect(isMultipleDays).toBe(true)
     expect(isMultipleDaysStart).toBe(true)
+    expect(eventWeekDuration).toBe(4)
   })
   test('second day', () => {
-    const date = dayjs().subtract(1, 'week').set('day', 4)
-    const { isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+    const date = dayjs().add(1, 'week').set('day', 4)
+    const { isMultipleDays, isMultipleDaysStart, eventWeekDuration } = utils.getEventSpanningInfo(
       events[7],
       date,
       date.day(),
+      0,
     )
 
     expect(isMultipleDays).toBe(true)
     expect(isMultipleDaysStart).toBe(false)
+    expect(eventWeekDuration).toBe(3)
   })
   test('first day of second week', () => {
-    const date = dayjs().set('day', 0)
+    const date = dayjs().add(2, 'week').set('day', 0)
 
-    const { isMultipleDays, isMultipleDaysStart } = utils.getEventSpanningInfo(
+    const { isMultipleDays, isMultipleDaysStart, eventWeekDuration } = utils.getEventSpanningInfo(
       events[7],
       date,
       date.day(),
+      0,
     )
 
     expect(isMultipleDays).toBe(true)
     expect(isMultipleDaysStart).toBe(true)
+    expect(eventWeekDuration).toBe(7)
   })
 })

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -159,6 +159,7 @@ function _CalendarBodyForMonthView<T>({
                             date={date}
                             dayOfTheWeek={ii}
                             calendarWidth={calendarWidth}
+                            isRTL={theme.isRTL}
                           />
                         ),
                       ],

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -121,11 +121,13 @@ function _CalendarBodyForMonthView<T>({
                 </Text>
                 {date &&
                   events
-                    .sort((a, b) => a.start.getUTCDate() - b.start.getUTCDate())
                     .sort((a, b) => {
-                      const aDuration = dayjs.duration(dayjs(a.end).diff(dayjs(a.start))).days()
-                      const bDuration = dayjs.duration(dayjs(b.end).diff(dayjs(b.start))).days()
-                      return bDuration - aDuration
+                      if (dayjs(a.start).isSame(b.start, 'day')) {
+                        const aDuration = dayjs.duration(dayjs(a.end).diff(dayjs(a.start))).days()
+                        const bDuration = dayjs.duration(dayjs(b.end).diff(dayjs(b.start))).days()
+                        return bDuration - aDuration
+                      }
+                      return a.start.getTime() - b.start.getTime()
                     })
                     .filter(({ start, end }) =>
                       date.isBetween(

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -47,6 +47,7 @@ function _CalendarBodyForMonthView<T>({
   weekStartsOn,
 }: CalendarBodyForMonthViewProps<T>) {
   const { now } = useNow(!hideNowIndicator)
+  const [calendarWidth, setCalendarWidth] = React.useState<number>(0)
 
   const panResponder = usePanResponder({
     onSwipeHorizontal,
@@ -72,6 +73,7 @@ function _CalendarBodyForMonthView<T>({
         { borderColor: theme.palette.gray['200'] },
         style,
       ]}
+      onLayout={({ nativeEvent: { layout } }) => setCalendarWidth(layout.width)}
       {...panResponder.panHandlers}
     >
       {weeks.map((week, i) => (
@@ -156,6 +158,7 @@ function _CalendarBodyForMonthView<T>({
                             renderEvent={renderEvent}
                             date={date}
                             dayOfTheWeek={ii}
+                            calendarWidth={calendarWidth}
                           />
                         ),
                       ],

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -121,8 +121,19 @@ function _CalendarBodyForMonthView<T>({
                 </Text>
                 {date &&
                   events
-                    .filter(({ start }) =>
-                      dayjs(start).isBetween(date.startOf('day'), date.endOf('day'), null, '[)'),
+                    .sort((a, b) => a.start.getUTCDate() - b.start.getUTCDate())
+                    .sort((a, b) => {
+                      const aDuration = dayjs.duration(dayjs(a.end).diff(dayjs(a.start))).days()
+                      const bDuration = dayjs.duration(dayjs(b.end).diff(dayjs(b.start))).days()
+                      return bDuration - aDuration
+                    })
+                    .filter(({ start, end }) =>
+                      date.isBetween(
+                        dayjs(start).startOf('day'),
+                        dayjs(end).endOf('day'),
+                        null,
+                        '[)',
+                      ),
                     )
                     .reduce(
                       (elements, event, index, events) => [
@@ -141,6 +152,8 @@ function _CalendarBodyForMonthView<T>({
                             eventCellStyle={eventCellStyle}
                             onPressEvent={onPressEvent}
                             renderEvent={renderEvent}
+                            date={date}
+                            dayOfTheWeek={ii}
                           />
                         ),
                       ],

--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -15,6 +15,7 @@ interface CalendarEventProps<T> {
   renderEvent?: EventRenderer<T>
   date: dayjs.Dayjs
   dayOfTheWeek: number
+  calendarWidth: number
 }
 
 function _CalendarEventForMonthView<T>({
@@ -24,12 +25,13 @@ function _CalendarEventForMonthView<T>({
   renderEvent,
   date,
   dayOfTheWeek,
+  calendarWidth,
 }: CalendarEventProps<T>) {
   const theme = useTheme()
 
-  const { eventWidth, isMultipleDays, isMultipleDaysStart } = React.useMemo(
-    () => getEventSpanningInfo(event, date, dayOfTheWeek),
-    [date, dayOfTheWeek, event],
+  const { eventWidth, isMultipleDays, isMultipleDaysStart, eventWeekDuration } = React.useMemo(
+    () => getEventSpanningInfo(event, date, dayOfTheWeek, calendarWidth),
+    [date, dayOfTheWeek, event, calendarWidth],
   )
 
   const touchableOpacityProps = useCalendarTouchableOpacityProps({
@@ -38,7 +40,13 @@ function _CalendarEventForMonthView<T>({
     onPressEvent,
     injectedStyles: [
       { backgroundColor: theme.palette.primary.main },
-      isMultipleDaysStart ? { position: 'absolute', width: eventWidth, zIndex: 100000 } : {},
+      isMultipleDaysStart && eventWeekDuration > 1
+        ? {
+            position: 'absolute',
+            width: eventWidth,
+            zIndex: 100000,
+          }
+        : {},
       u['mt-2'],
     ],
   })
@@ -48,7 +56,7 @@ function _CalendarEventForMonthView<T>({
   }
 
   return (
-    <View style={{ minHeight: 22 }}>
+    <View style={{ minHeight: 22, position: 'relative' }}>
       {((!isMultipleDays && date.isSame(event.start, 'day')) ||
         (isMultipleDays && isMultipleDaysStart)) && (
         <TouchableOpacity {...touchableOpacityProps}>

--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import * as React from 'react'
-import { Dimensions, Text, TouchableOpacity, View } from 'react-native'
+import { Text, TouchableOpacity, View } from 'react-native'
 
 import { u } from '../commonStyles'
 import { useCalendarTouchableOpacityProps } from '../hooks/useCalendarTouchableOpacityProps'

--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -16,6 +16,7 @@ interface CalendarEventProps<T> {
   date: dayjs.Dayjs
   dayOfTheWeek: number
   calendarWidth: number
+  isRTL: boolean
 }
 
 function _CalendarEventForMonthView<T>({
@@ -26,6 +27,7 @@ function _CalendarEventForMonthView<T>({
   date,
   dayOfTheWeek,
   calendarWidth,
+  isRTL,
 }: CalendarEventProps<T>) {
   const theme = useTheme()
 
@@ -47,6 +49,7 @@ function _CalendarEventForMonthView<T>({
             zIndex: 100000,
           }
         : {},
+      isRTL ? { right: 0 } : { left: 0 },
       u['mt-2'],
     ],
   })

--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -1,5 +1,6 @@
+import dayjs from 'dayjs'
 import * as React from 'react'
-import { Text, TouchableOpacity } from 'react-native'
+import { Text, TouchableOpacity, View } from 'react-native'
 
 import { u } from '../commonStyles'
 import { useCalendarTouchableOpacityProps } from '../hooks/useCalendarTouchableOpacityProps'
@@ -12,6 +13,8 @@ interface CalendarEventProps<T> {
   onPressEvent?: (event: ICalendarEvent<T>) => void
   eventCellStyle?: EventCellStyle<T>
   renderEvent?: EventRenderer<T>
+  date: dayjs.Dayjs
+  dayOfTheWeek: number
 }
 
 function _CalendarEventForMonthView<T>({
@@ -19,14 +22,38 @@ function _CalendarEventForMonthView<T>({
   onPressEvent,
   eventCellStyle,
   renderEvent,
+  date,
+  dayOfTheWeek,
 }: CalendarEventProps<T>) {
   const theme = useTheme()
+
+  // adding + 1 because durations start at 0
+  const eventDuration = dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).days() + 1
+  const eventDaysLeft = dayjs.duration(dayjs(event.end).diff(date)).days() + 1
+  const weekDaysLeft = 7 - dayOfTheWeek
+  //
+  const eventWeekDuration =
+    eventDuration > weekDaysLeft
+      ? weekDaysLeft
+      : dayOfTheWeek === 0 && eventDaysLeft < eventDuration
+      ? eventDaysLeft
+      : eventDuration
+  const isMultipleDays = eventDuration > 1
+  const isMultipleDaysStart =
+    isMultipleDays &&
+    (date.isSame(event.start, 'day') || (dayOfTheWeek === 0 && date.isAfter(event.start)))
 
   const touchableOpacityProps = useCalendarTouchableOpacityProps({
     event,
     eventCellStyle,
     onPressEvent,
-    injectedStyles: [{ backgroundColor: theme.palette.primary.main }, u['mt-2']],
+    injectedStyles: [
+      { backgroundColor: theme.palette.primary.main },
+      isMultipleDaysStart
+        ? { position: 'absolute', width: `${eventWeekDuration * 100}%`, zIndex: 100000 }
+        : {},
+      u['mt-2'],
+    ],
   })
 
   if (renderEvent) {
@@ -34,14 +61,23 @@ function _CalendarEventForMonthView<T>({
   }
 
   return (
-    <TouchableOpacity {...touchableOpacityProps}>
-      <Text
-        style={[{ color: theme.palette.primary.contrastText }, theme.typography.xs, u['truncate']]}
-        numberOfLines={1}
-      >
-        {event.title}
-      </Text>
-    </TouchableOpacity>
+    <View style={{ minHeight: 22 }}>
+      {((!isMultipleDays && date.isSame(event.start, 'day')) ||
+        (isMultipleDays && isMultipleDaysStart)) && (
+        <TouchableOpacity {...touchableOpacityProps}>
+          <Text
+            style={[
+              { color: theme.palette.primary.contrastText },
+              theme.typography.xs,
+              u['truncate'],
+            ]}
+            numberOfLines={1}
+          >
+            {event.title}
+          </Text>
+        </TouchableOpacity>
+      )}
+    </View>
   )
 }
 

--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -46,7 +46,7 @@ function _CalendarEventForMonthView<T>({
         ? {
             position: 'absolute',
             width: eventWidth,
-            zIndex: 100000,
+            zIndex: 10000,
           }
         : {},
       isRTL ? { right: 0 } : { left: 0 },
@@ -59,7 +59,7 @@ function _CalendarEventForMonthView<T>({
   }
 
   return (
-    <View style={{ minHeight: 22, position: 'relative' }}>
+    <View style={{ minHeight: 22 }}>
       {((!isMultipleDays && date.isSame(event.start, 'day')) ||
         (isMultipleDays && isMultipleDaysStart)) && (
         <TouchableOpacity {...touchableOpacityProps}>
@@ -68,6 +68,7 @@ function _CalendarEventForMonthView<T>({
               { color: theme.palette.primary.contrastText },
               theme.typography.xs,
               u['truncate'],
+              isRTL && { textAlign: 'right' },
             ]}
             numberOfLines={1}
           >

--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -6,7 +6,7 @@ import { u } from '../commonStyles'
 import { useCalendarTouchableOpacityProps } from '../hooks/useCalendarTouchableOpacityProps'
 import { EventCellStyle, EventRenderer, ICalendarEvent } from '../interfaces'
 import { useTheme } from '../theme/ThemeContext'
-import { typedMemo } from '../utils'
+import { getEventSpanningInfo, typedMemo } from '../utils'
 
 interface CalendarEventProps<T> {
   event: ICalendarEvent<T>
@@ -26,26 +26,11 @@ function _CalendarEventForMonthView<T>({
   dayOfTheWeek,
 }: CalendarEventProps<T>) {
   const theme = useTheme()
-  const { width } = Dimensions.get('window')
-  const dayWidth = width / 7
 
-  // adding + 1 because durations start at 0
-  const eventDuration = dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).days() + 1
-  const eventDaysLeft = dayjs.duration(dayjs(event.end).diff(date)).days() + 1
-  const weekDaysLeft = 7 - dayOfTheWeek
-  const isMultipleDays = eventDuration > 1
-  // This is to determine how many days from the event to show during a week
-  const eventWeekDuration =
-    eventDuration > weekDaysLeft
-      ? weekDaysLeft
-      : dayOfTheWeek === 0 && eventDaysLeft < eventDuration
-      ? eventDaysLeft
-      : eventDuration
-  const isMultipleDaysStart =
-    isMultipleDays &&
-    (date.isSame(event.start, 'day') || (dayOfTheWeek === 0 && date.isAfter(event.start)))
-  // - 6 to take in account the padding
-  const eventWidth = dayWidth * eventWeekDuration - 6
+  const { eventWidth, isMultipleDays, isMultipleDaysStart } = React.useMemo(
+    () => getEventSpanningInfo(event, date, dayOfTheWeek),
+    [date, dayOfTheWeek, event],
+  )
 
   const touchableOpacityProps = useCalendarTouchableOpacityProps({
     event,

--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs'
 import * as React from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
+import { Dimensions, Text, TouchableOpacity, View } from 'react-native'
 
 import { u } from '../commonStyles'
 import { useCalendarTouchableOpacityProps } from '../hooks/useCalendarTouchableOpacityProps'
@@ -26,22 +26,26 @@ function _CalendarEventForMonthView<T>({
   dayOfTheWeek,
 }: CalendarEventProps<T>) {
   const theme = useTheme()
+  const { width } = Dimensions.get('window')
+  const dayWidth = width / 7
 
   // adding + 1 because durations start at 0
   const eventDuration = dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).days() + 1
   const eventDaysLeft = dayjs.duration(dayjs(event.end).diff(date)).days() + 1
   const weekDaysLeft = 7 - dayOfTheWeek
-  //
+  const isMultipleDays = eventDuration > 1
+  // This is to determine how many days from the event to show during a week
   const eventWeekDuration =
     eventDuration > weekDaysLeft
       ? weekDaysLeft
       : dayOfTheWeek === 0 && eventDaysLeft < eventDuration
       ? eventDaysLeft
       : eventDuration
-  const isMultipleDays = eventDuration > 1
   const isMultipleDaysStart =
     isMultipleDays &&
     (date.isSame(event.start, 'day') || (dayOfTheWeek === 0 && date.isAfter(event.start)))
+  // - 6 to take in account the padding
+  const eventWidth = dayWidth * eventWeekDuration - 6
 
   const touchableOpacityProps = useCalendarTouchableOpacityProps({
     event,
@@ -49,9 +53,7 @@ function _CalendarEventForMonthView<T>({
     onPressEvent,
     injectedStyles: [
       { backgroundColor: theme.palette.primary.main },
-      isMultipleDaysStart
-        ? { position: 'absolute', width: `${eventWeekDuration * 100}%`, zIndex: 100000 }
-        : {},
+      isMultipleDaysStart ? { position: 'absolute', width: eventWidth, zIndex: 100000 } : {},
       u['mt-2'],
     ],
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+
 import { Calendar } from './components/Calendar'
+
+dayjs.extend(duration)
 
 export * from './components/Calendar'
 export * from './components/CalendarBody'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 import React from 'react'
+import { Dimensions } from 'react-native'
 
 import { OVERLAP_PADDING } from './commonStyles'
 import { ICalendarEvent, Mode, WeekNum } from './interfaces'
@@ -213,4 +214,35 @@ function weekDaysCount(weekStartsOn: WeekNum, weekEndsOn: WeekNum) {
   }
   // default
   return 1
+}
+
+export function getEventSpanningInfo(
+  event: ICalendarEvent<any>,
+  date: dayjs.Dayjs,
+  dayOfTheWeek: number,
+) {
+  const { width } = Dimensions.get('window')
+  const dayWidth = width / 7
+
+  // adding + 1 because durations start at 0
+  const eventDuration = dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).days() + 1
+  const eventDaysLeft = dayjs.duration(dayjs(event.end).diff(date)).days() + 1
+  const weekDaysLeft = 7 - dayOfTheWeek
+  const isMultipleDays = eventDuration > 1
+  // This is to determine how many days from the event to show during a week
+  const eventWeekDuration =
+    eventDuration > weekDaysLeft
+      ? weekDaysLeft
+      : dayOfTheWeek === 0 && eventDaysLeft < eventDuration
+      ? eventDaysLeft
+      : eventDuration
+  const isMultipleDaysStart =
+    isMultipleDays &&
+    (date.isSame(event.start, 'day') ||
+      (dayOfTheWeek === 0 && date.isAfter(event.start)) ||
+      date.get('date') === 1)
+  // - 6 to take in account the padding
+  const eventWidth = dayWidth * eventWeekDuration - 6
+
+  return { eventWidth, isMultipleDays, isMultipleDaysStart }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs'
 import React from 'react'
-import { Dimensions } from 'react-native'
 
 import { OVERLAP_PADDING } from './commonStyles'
 import { ICalendarEvent, Mode, WeekNum } from './interfaces'
@@ -220,9 +219,9 @@ export function getEventSpanningInfo(
   event: ICalendarEvent<any>,
   date: dayjs.Dayjs,
   dayOfTheWeek: number,
+  calendarWidth: number,
 ) {
-  const { width } = Dimensions.get('window')
-  const dayWidth = width / 7
+  const dayWidth = calendarWidth / 7
 
   // adding + 1 because durations start at 0
   const eventDuration = dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).days() + 1
@@ -244,5 +243,5 @@ export function getEventSpanningInfo(
   // - 6 to take in account the padding
   const eventWidth = dayWidth * eventWeekDuration - 6
 
-  return { eventWidth, isMultipleDays, isMultipleDaysStart }
+  return { eventWidth, isMultipleDays, isMultipleDaysStart, eventWeekDuration }
 }

--- a/stories/desktop.stories.tsx
+++ b/stories/desktop.stories.tsx
@@ -5,7 +5,7 @@ import { Alert, Dimensions, View } from 'react-native'
 
 import { Calendar } from '../src'
 import { CONTROL_HEIGHT, Control } from './components/Control'
-import { customEventRenderer, events } from './events'
+import { customEventRenderer, events, spanningEvents } from './events'
 import { useEvents } from './hooks'
 import { styles } from './styles'
 import { themes } from './themes'
@@ -89,6 +89,35 @@ storiesOf('showcase - Desktop', module)
           events={state.events}
           onPressEvent={(event) => alert(event.title)}
           onPressCell={state.addEvent}
+        />
+      </View>
+    )
+  })
+  .add('Month mode - Spanning Events', () => {
+    const state = useEvents(spanningEvents)
+    return (
+      <View style={styles.desktop}>
+        <Calendar
+          mode="month"
+          height={SCREEN_HEIGHT}
+          events={state.events}
+          onPressEvent={(event) => alert(event.title)}
+          onPressCell={state.addEvent}
+        />
+      </View>
+    )
+  })
+  .add('Month mode - Spanning Events RTL', () => {
+    const state = useEvents(spanningEvents)
+    return (
+      <View style={styles.desktop}>
+        <Calendar
+          mode="month"
+          height={SCREEN_HEIGHT}
+          events={state.events}
+          onPressEvent={(event) => alert(event.title)}
+          onPressCell={state.addEvent}
+          isRTL
         />
       </View>
     )

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -57,6 +57,34 @@ export const events: ICalendarEvent<{ color?: string }>[] = [
   },
 ]
 
+export const spanningEvents: ICalendarEvent<{ color?: string }>[] = [
+  {
+    title: 'Watch Boxing',
+    start: dayjs().subtract(1, 'week').set('hour', 14).set('minute', 30).toDate(),
+    end: dayjs().subtract(1, 'week').set('hour', 15).set('minute', 30).toDate(),
+  },
+  {
+    title: 'Laundry',
+    start: dayjs().subtract(1, 'week').set('hour', 1).set('minute', 30).toDate(),
+    end: dayjs().subtract(1, 'week').set('hour', 2).set('minute', 30).toDate(),
+  },
+  {
+    title: 'Meeting',
+    start: dayjs().subtract(1, 'week').set('hour', 10).set('minute', 0).toDate(),
+    end: dayjs().add(1, 'week').set('hour', 10).set('minute', 30).toDate(),
+  },
+  {
+    title: 'Coffee break',
+    start: dayjs().set('hour', 14).set('minute', 30).toDate(),
+    end: dayjs().add(1, 'week').set('hour', 15).set('minute', 30).toDate(),
+  },
+  {
+    title: 'Repair my car',
+    start: dayjs().add(1, 'day').set('hour', 7).set('minute', 45).toDate(),
+    end: dayjs().add(4, 'day').set('hour', 13).set('minute', 30).toDate(),
+  },
+]
+
 export interface MyCustomEventType {
   color?: string
 }


### PR DESCRIPTION
Here's my take on implementing spanning events, for now I've only implemented it for the month mode.

In `CalendarBodyForMonthView` I've change the filtering and add sorting for better rendering, sorting could be handled on the client side but I think at least the one I've implemented is needed.

In `CalendarEventForMonthView` I determine how much of the event to show during the current week, then on the starting day of the event or the first day of the week (when the event spans over multiple weeks) I render the event with `position: absolute` and on the other days I render an empty `View` so that other events are push downed in the column.

I still think it needs more testing and review but It's a good start, main problem right now is render in landscape mode.
Please let me know your thought and I hope we can work together to finish the implementation, I really like this library and would like to use it in my company's project.

![Simulator Screen Shot - iPhone 12 - 2021-08-27 at 14 14 15](https://user-images.githubusercontent.com/5366008/131075678-09dbaa74-4ce4-4957-9031-0c79d7f3a084.png)
