### PR TITLE
Added startDate prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ export interface CalendarProps<T> {
   onPressCell?: (date: Date) => void
   onPressDateHeader?: (date: Date) => void
   onPressEvent?: (event: ICalendarEvent<T>) => void
+  startDate?: Date
 }
 ```
 
@@ -146,6 +147,7 @@ export interface CalendarProps<T> {
 | `isRTL`               | no       | `boolean`                                              | Switches the direction of the layout for use with RTL languages. Defaults to false.                                                                                                                                                                                                                                                                                                                                                                             |
 | `renderEvent`         | no       | `EventRenderer`                                        | Custom event renderer. See below type definition.                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `renderHeader`        | no       | `HeaderRenderer`                                       | Custom header renderer.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `startDate`           | no       | `Date`                                                 | If provided, the calendar will show preview of date-range having this date.                                                                                                                                                                                                                                                                                                                                                                                     |
 
 ## EventRenderer
 

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -73,6 +73,7 @@ export interface CalendarContainerProps<T> {
   onPressEvent?: (event: ICalendarEvent<T>) => void
   weekEndsOn?: WeekNum
   maxVisibleEventCount?: number
+  startDate?: Date
 }
 
 function _CalendarContainer<T>({
@@ -100,8 +101,9 @@ function _CalendarContainer<T>({
   renderHeaderForMonthView: HeaderComponentForMonthView = CalendarHeaderForMonthView,
   weekEndsOn = 6,
   maxVisibleEventCount = 3,
+  startDate,
 }: CalendarContainerProps<T>) {
-  const [targetDate, setTargetDate] = React.useState(dayjs(date))
+  const [targetDate, setTargetDate] = React.useState(dayjs(startDate ?? date))
 
   React.useEffect(() => {
     if (date) {


### PR DESCRIPTION
# Backgroud
I was working on a project and I had a usecase where I wanted to see a different range of date than current date and the one in events. 

## Usage
If provided, the calendar will show a range of dates having this date