### PR TITLE
Update package.json for issue 568

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "merge-anything": "^4.0.1"
   },
   "peerDependencies": {
-    "react": "^16.8.3",
-    "react-native": "^0.59.0"
+    "react": "^16.8.3||^17.0.0",
+    "react-native": "^0.59.0||^0.60.0||^0.61.0||^0.62.0||^0.63.0||^0.64.0||^0.65.0||^0.66.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",


### PR DESCRIPTION
Support React Native 0.59 and newer versions - see issue #568 of acro5piano/react-native-big-calendar