### PR TITLE
feat: add support to style calendar cells based on cell date

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,6 @@ export interface Palette {
 export interface ThemeInterface {
   palette: {
     primary: Palette
-    evenCellBg: string
-    oddCellBg: string
     nowIndicator: string
     gray: {
       100: string
@@ -293,8 +291,6 @@ const darkTheme = {
       main: '#6185d0',
       contrastText: '#000',
     },
-    evenCellBg: '#333',
-    oddCellBg: '#555',
     gray: {
       '100': '#333',
       '200': '#666',

--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -6,6 +6,7 @@ import { u } from '../commonStyles'
 import { useNow } from '../hooks/useNow'
 import { usePanResponder } from '../hooks/usePanResponder'
 import {
+  CalendarCellStyle,
   EventCellStyle,
   EventRenderer,
   HorizontalDirection,
@@ -43,6 +44,7 @@ interface CalendarBodyProps<T extends ICalendarEventBase> {
   showTime: boolean
   style: ViewStyle
   eventCellStyle?: EventCellStyle<T>
+  calendarCellStyle?: CalendarCellStyle
   hideNowIndicator?: boolean
   overlapOffset?: number
   onPressCell?: (date: Date) => void
@@ -63,6 +65,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
   events,
   onPressEvent,
   eventCellStyle,
+  calendarCellStyle,
   ampm,
   showTime,
   scrollOffsetMinutes,
@@ -166,6 +169,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
                   hour={hour}
                   onPress={_onPressCell}
                   index={index}
+                  calendarCellStyle={calendarCellStyle}
                 />
               ))}
 

--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -148,13 +148,12 @@ function _CalendarBody<T extends ICalendarEventBase>({
           {...(Platform.OS === 'web' ? panResponder.panHandlers : {})}
         >
           <View style={[u['z-20'], u['w-50']]}>
-            {hours.map((hour, index) => (
+            {hours.map((hour) => (
               <HourGuideColumn
                 key={hour}
                 cellHeight={cellHeight}
                 hour={hour}
                 ampm={ampm}
-                index={index}
                 hourStyle={hourStyle}
               />
             ))}

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -7,6 +7,7 @@ import { u } from '../commonStyles'
 import { useNow } from '../hooks/useNow'
 import { usePanResponder } from '../hooks/usePanResponder'
 import {
+  CalendarCellStyle,
   EventCellStyle,
   EventRenderer,
   HorizontalDirection,
@@ -23,6 +24,8 @@ interface CalendarBodyForMonthViewProps<T extends ICalendarEventBase> {
   events: T[]
   style: ViewStyle
   eventCellStyle?: EventCellStyle<T>
+  calendarCellStyle?: CalendarCellStyle
+  calendarCellTextStyle?: CalendarCellStyle
   hideNowIndicator?: boolean
   onPressCell?: (date: Date) => void
   onPressEvent?: (event: T) => void
@@ -41,6 +44,8 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
   events,
   onPressEvent,
   eventCellStyle,
+  calendarCellStyle,
+  calendarCellTextStyle,
   onSwipeHorizontal,
   hideNowIndicator,
   renderEvent,
@@ -59,6 +64,19 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
 
   const minCellHeight = containerHeight / 5 - 30
   const theme = useTheme()
+
+  const getCalendarCellStyle = React.useMemo(
+    () => (typeof calendarCellStyle === 'function' ? calendarCellStyle : () => calendarCellStyle),
+    [calendarCellStyle],
+  )
+
+  const getCalendarCellTextStyle = React.useMemo(
+    () =>
+      typeof calendarCellTextStyle === 'function'
+        ? calendarCellTextStyle
+        : () => calendarCellTextStyle,
+    [calendarCellTextStyle],
+  )
 
   return (
     <View
@@ -106,6 +124,9 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                   {
                     minHeight: minCellHeight,
                   },
+                  {
+                    ...getCalendarCellStyle(dayjs(date), i),
+                  },
                 ]}
                 key={ii}
               >
@@ -118,6 +139,9 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                         date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
                           ? theme.palette.primary.main
                           : theme.palette.gray['800'],
+                    },
+                    {
+                      ...getCalendarCellTextStyle(dayjs(date), i),
                     },
                   ]}
                 >

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -8,6 +8,7 @@ import { useNow } from '../hooks/useNow'
 import { usePanResponder } from '../hooks/usePanResponder'
 import {
   CalendarCellStyle,
+  CalendarCellTextStyle,
   EventCellStyle,
   EventRenderer,
   HorizontalDirection,
@@ -25,7 +26,7 @@ interface CalendarBodyForMonthViewProps<T extends ICalendarEventBase> {
   style: ViewStyle
   eventCellStyle?: EventCellStyle<T>
   calendarCellStyle?: CalendarCellStyle
-  calendarCellTextStyle?: CalendarCellStyle
+  calendarCellTextStyle?: CalendarCellTextStyle
   hideNowIndicator?: boolean
   onPressCell?: (date: Date) => void
   onPressEvent?: (event: T) => void
@@ -125,7 +126,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                     minHeight: minCellHeight,
                   },
                   {
-                    ...getCalendarCellStyle(dayjs(date), i),
+                    ...getCalendarCellStyle(date?.toDate(), i),
                   },
                 ]}
                 key={ii}
@@ -141,7 +142,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                           : theme.palette.gray['800'],
                     },
                     {
-                      ...getCalendarCellTextStyle(dayjs(date), i),
+                      ...getCalendarCellTextStyle(date?.toDate(), i),
                     },
                   ]}
                 >

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -5,6 +5,7 @@ import { TextStyle, ViewStyle } from 'react-native'
 import { MIN_HEIGHT } from '../commonStyles'
 import {
   CalendarCellStyle,
+  CalendarCellTextStyle,
   DateRangeHandler,
   EventCellStyle,
   EventRenderer,
@@ -55,7 +56,7 @@ export interface CalendarContainerProps<T extends ICalendarEventBase> {
   // Custom style
   eventCellStyle?: EventCellStyle<T>
   calendarCellStyle?: CalendarCellStyle
-  calendarCellTextStyle?: CalendarCellStyle
+  calendarCellTextStyle?: CalendarCellTextStyle
   calendarContainerStyle?: ViewStyle
   headerContainerStyle?: ViewStyle
   headerContentStyle?: ViewStyle

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -4,6 +4,7 @@ import { TextStyle, ViewStyle } from 'react-native'
 
 import { MIN_HEIGHT } from '../commonStyles'
 import {
+  CalendarCellStyle,
   DateRangeHandler,
   EventCellStyle,
   EventRenderer,
@@ -53,6 +54,8 @@ export interface CalendarContainerProps<T extends ICalendarEventBase> {
 
   // Custom style
   eventCellStyle?: EventCellStyle<T>
+  calendarCellStyle?: CalendarCellStyle
+  calendarCellTextStyle?: CalendarCellStyle
   calendarContainerStyle?: ViewStyle
   headerContainerStyle?: ViewStyle
   headerContentStyle?: ViewStyle
@@ -97,6 +100,8 @@ function _CalendarContainer<T extends ICalendarEventBase>({
   ampm = false,
   date,
   eventCellStyle,
+  calendarCellStyle,
+  calendarCellTextStyle,
   locale = 'en',
   hideNowIndicator = false,
   mode = 'week',
@@ -218,6 +223,8 @@ function _CalendarContainer<T extends ICalendarEventBase>({
           containerHeight={height}
           events={[...daytimeEvents, ...allDayEvents]}
           eventCellStyle={eventCellStyle}
+          calendarCellStyle={calendarCellStyle}
+          calendarCellTextStyle={calendarCellTextStyle}
           weekStartsOn={weekStartsOn}
           hideNowIndicator={hideNowIndicator}
           onPressCell={onPressCell}
@@ -254,6 +261,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
         containerHeight={height}
         events={daytimeEvents}
         eventCellStyle={eventCellStyle}
+        calendarCellStyle={calendarCellStyle}
         hideNowIndicator={hideNowIndicator}
         overlapOffset={overlapOffset}
         scrollOffsetMinutes={scrollOffsetMinutes}

--- a/src/components/HourGuideCell.tsx
+++ b/src/components/HourGuideCell.tsx
@@ -5,7 +5,6 @@ import { CalendarCellStyle } from 'src'
 
 import { u } from '../commonStyles'
 import { useTheme } from '../theme/ThemeContext'
-import { isPair } from '../utils'
 
 interface HourGuideCellProps {
   cellHeight: number

--- a/src/components/HourGuideCell.tsx
+++ b/src/components/HourGuideCell.tsx
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs'
 import * as React from 'react'
 import { TouchableWithoutFeedback, View } from 'react-native'
+import { CalendarCellStyle } from 'src'
 
 import { u } from '../commonStyles'
 import { useTheme } from '../theme/ThemeContext'
@@ -12,13 +13,23 @@ interface HourGuideCellProps {
   date: dayjs.Dayjs
   hour: number
   index: number
+  calendarCellStyle?: CalendarCellStyle
 }
 
-export const HourGuideCell = ({ cellHeight, onPress, date, hour, index }: HourGuideCellProps) => {
+export const HourGuideCell = ({
+  cellHeight,
+  onPress,
+  date,
+  hour,
+  index,
+  calendarCellStyle,
+}: HourGuideCellProps) => {
   const theme = useTheme()
 
-  const evenCellBg = theme.palette.evenCellBg
-  const oddCellBg = theme.palette.oddCellBg
+  const getCalendarCellStyle = React.useMemo(
+    () => (typeof calendarCellStyle === 'function' ? calendarCellStyle : () => calendarCellStyle),
+    [calendarCellStyle],
+  )
 
   return (
     <TouchableWithoutFeedback onPress={() => onPress(date.hour(hour).minute(0))}>
@@ -28,7 +39,7 @@ export const HourGuideCell = ({ cellHeight, onPress, date, hour, index }: HourGu
           u['border-b'],
           { borderColor: theme.palette.gray['200'] },
           { height: cellHeight },
-          { backgroundColor: isPair(index) ? evenCellBg : oddCellBg },
+          { ...getCalendarCellStyle(date, index) },
         ]}
       />
     </TouchableWithoutFeedback>

--- a/src/components/HourGuideCell.tsx
+++ b/src/components/HourGuideCell.tsx
@@ -38,7 +38,7 @@ export const HourGuideCell = ({
           u['border-b'],
           { borderColor: theme.palette.gray['200'] },
           { height: cellHeight },
-          { ...getCalendarCellStyle(date, index) },
+          { ...getCalendarCellStyle(date.toDate(), index) },
         ]}
       />
     </TouchableWithoutFeedback>

--- a/src/components/HourGuideColumn.tsx
+++ b/src/components/HourGuideColumn.tsx
@@ -4,7 +4,7 @@ import { Text, TextStyle, View } from 'react-native'
 import { u } from '../commonStyles'
 import { useTheme } from '../theme/ThemeContext'
 import { formatHour } from '../utils'
-import { isPair, objHasContent } from '../utils'
+import { objHasContent } from '../utils'
 
 interface HourGuideColumnProps {
   cellHeight: number

--- a/src/components/HourGuideColumn.tsx
+++ b/src/components/HourGuideColumn.tsx
@@ -10,27 +10,18 @@ interface HourGuideColumnProps {
   cellHeight: number
   hour: number
   ampm: boolean
-  index: number
   hourStyle: TextStyle
 }
 
-const _HourGuideColumn = ({
-  cellHeight,
-  hour,
-  ampm,
-  index,
-  hourStyle = {},
-}: HourGuideColumnProps) => {
+const _HourGuideColumn = ({ cellHeight, hour, ampm, hourStyle = {} }: HourGuideColumnProps) => {
   const theme = useTheme()
   const textStyle = React.useMemo(
     () => ({ color: theme.palette.gray[500], fontSize: theme.typography.xs.fontSize }),
     [theme],
   )
-  const evenCellBg = theme.palette.evenCellBg
-  const oddCellBg = theme.palette.oddCellBg
 
   return (
-    <View style={{ height: cellHeight, backgroundColor: isPair(index) ? evenCellBg : oddCellBg }}>
+    <View style={{ height: cellHeight }}>
       <Text style={[objHasContent(hourStyle) ? hourStyle : textStyle, u['text-center']]}>
         {formatHour(hour, ampm)}
       </Text>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import { ReactElement } from 'react'
 import { RecursiveArray, ViewStyle } from 'react-native'
 
@@ -27,6 +28,10 @@ export type CalendarTouchableOpacityProps = {
 export type Mode = '3days' | 'week' | 'day' | 'custom' | 'month'
 
 export type EventCellStyle<T extends ICalendarEventBase> = ViewStyle | ((event: T) => ViewStyle)
+
+export type CalendarCellStyle =
+  | ViewStyle
+  | ((date: dayjs.Dayjs, hourRowIndex?: Number) => ViewStyle)
 
 export type WeekNum = 0 | 1 | 2 | 3 | 4 | 5 | 6
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,5 @@
-import dayjs from 'dayjs'
 import { ReactElement } from 'react'
-import { RecursiveArray, ViewStyle } from 'react-native'
+import { RecursiveArray, TextStyle, ViewStyle } from 'react-native'
 
 import { CalendarHeaderProps } from './components/CalendarHeader'
 import { CalendarHeaderForMonthViewProps } from './components/CalendarHeaderForMonthView'
@@ -29,9 +28,9 @@ export type Mode = '3days' | 'week' | 'day' | 'custom' | 'month'
 
 export type EventCellStyle<T extends ICalendarEventBase> = ViewStyle | ((event: T) => ViewStyle)
 
-export type CalendarCellStyle =
-  | ViewStyle
-  | ((date: Date, hourRowIndex: number) => ViewStyle)
+export type CalendarCellStyle = ViewStyle | ((date?: Date, hourRowIndex?: number) => ViewStyle)
+
+export type CalendarCellTextStyle = TextStyle | ((date?: Date, hourRowIndex?: number) => TextStyle)
 
 export type WeekNum = 0 | 1 | 2 | 3 | 4 | 5 | 6
 

--- a/src/theme/ThemeInterface.ts
+++ b/src/theme/ThemeInterface.ts
@@ -18,8 +18,6 @@ export type Typography = Pick<
 export interface ThemeInterface {
   palette: {
     primary: Palette
-    evenCellBg: string
-    oddCellBg: string
     nowIndicator: string
     gray: {
       // 50: string

--- a/src/theme/defaultTheme.ts
+++ b/src/theme/defaultTheme.ts
@@ -7,8 +7,6 @@ export const defaultTheme: ThemeInterface = {
       main: 'rgb(66, 133, 244)',
       contrastText: '#fff',
     },
-    evenCellBg: '#fff',
-    oddCellBg: '#fff',
     nowIndicator: 'red',
     gray: {
       // 50: '#fafafa',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -247,10 +247,6 @@ export function getEventSpanningInfo(
   return { eventWidth, isMultipleDays, isMultipleDaysStart, eventWeekDuration }
 }
 
-export function isPair(i: number): boolean {
-  return i % 2 === 0
-}
-
 export function objHasContent(obj: ViewStyle | TextStyle): boolean {
   return !!Object.keys(obj).length
 }

--- a/stories/desktop.stories.tsx
+++ b/stories/desktop.stories.tsx
@@ -292,8 +292,6 @@ storiesOf('showcase - Desktop', module)
                 main: 'purple',
                 contrastText: '#fff',
               },
-              evenCellBg: '#fff',
-              oddCellBg: '#fff',
             },
           }}
         />

--- a/stories/mobile.stories.tsx
+++ b/stories/mobile.stories.tsx
@@ -159,7 +159,7 @@ storiesOf('showcase - Mobile', module)
         height={MOBILE_HEIGHT}
         events={events}
         mode={'month'}
-        calendarCellStyle={(_, index) => {
+        calendarCellStyle={(_, index = 0) => {
           const isEvenRow = index % 2 === 0
 
           return {
@@ -219,7 +219,7 @@ storiesOf('showcase - Mobile', module)
         height={MOBILE_HEIGHT}
         events={events}
         mode={'week'}
-        calendarCellStyle={(_, index) => {
+        calendarCellStyle={(_, index = 0) => {
           const isEvenRow: boolean = index % 2 === 0
 
           return {

--- a/stories/mobile.stories.tsx
+++ b/stories/mobile.stories.tsx
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/react'
+import dayjs from 'dayjs'
 import React from 'react'
 import { Alert, View } from 'react-native'
 
@@ -104,6 +105,127 @@ storiesOf('showcase - Mobile', module)
         mode={'custom'}
         weekStartsOn={1}
         weekEndsOn={5}
+      />
+    </View>
+  ))
+  .add('Month - Calendar Cell Style', () => (
+    <View style={styles.mobile}>
+      <Calendar
+        height={MOBILE_HEIGHT}
+        events={events}
+        mode={'month'}
+        calendarCellStyle={(date) => {
+          let cellStyles = {
+            backgroundColor: 'white',
+            color: 'white',
+          }
+
+          const now = dayjs()
+
+          const isBefore = dayjs(date).startOf('day').isBefore(now.startOf('day'))
+          const isToday = dayjs(date).startOf('day').isSame(now.startOf('day'))
+          const isAfter = dayjs(date).startOf('day').isAfter(now.startOf('day'))
+
+          if (isBefore) {
+            cellStyles = {
+              ...cellStyles,
+              backgroundColor: 'red',
+            }
+          } else if (isToday) {
+            cellStyles = {
+              ...cellStyles,
+              backgroundColor: 'blue',
+            }
+          } else if (isAfter) {
+            cellStyles = {
+              ...cellStyles,
+              backgroundColor: 'green',
+            }
+          } else {
+            cellStyles = {
+              ...cellStyles,
+            }
+          }
+
+          return cellStyles
+        }}
+        calendarCellTextStyle={{ color: 'white' }}
+      />
+    </View>
+  ))
+  .add('Month - Event Cell - Even and Odd Row BgColor', () => (
+    <View style={styles.mobile}>
+      <Calendar
+        height={MOBILE_HEIGHT}
+        events={events}
+        mode={'month'}
+        calendarCellStyle={(_, index) => {
+          const isEvenRow = index % 2 === 0
+
+          return {
+            backgroundColor: isEvenRow ? 'red' : 'green',
+          }
+        }}
+      />
+    </View>
+  ))
+  .add('Week - Calendar Cell Style', () => (
+    <View style={styles.mobile}>
+      <Calendar
+        height={MOBILE_HEIGHT}
+        events={events}
+        mode={'week'}
+        calendarCellStyle={(date) => {
+          let cellStyles = {
+            backgroundColor: 'white',
+            color: 'black',
+          }
+
+          const now = dayjs()
+
+          const isBefore = dayjs(date).startOf('day').isBefore(now.startOf('day'))
+          const isToday = dayjs(date).startOf('day').isSame(now.startOf('day'))
+          const isAfter = dayjs(date).startOf('day').isAfter(now.startOf('day'))
+
+          if (isBefore) {
+            cellStyles = {
+              ...cellStyles,
+              backgroundColor: 'red',
+            }
+          } else if (isToday) {
+            cellStyles = {
+              ...cellStyles,
+              backgroundColor: 'blue',
+            }
+          } else if (isAfter) {
+            cellStyles = {
+              ...cellStyles,
+              backgroundColor: 'green',
+            }
+          } else {
+            cellStyles = {
+              ...cellStyles,
+            }
+          }
+
+          return cellStyles
+        }}
+      />
+    </View>
+  ))
+  .add('Week - Calendar Cell - Even and Odd Row BgColor', () => (
+    <View style={styles.mobile}>
+      <Calendar
+        height={MOBILE_HEIGHT}
+        events={events}
+        mode={'week'}
+        calendarCellStyle={(_, index) => {
+          const isEvenRow: boolean = index % 2 === 0
+
+          return {
+            backgroundColor: isEvenRow ? 'red' : 'green',
+          }
+        }}
       />
     </View>
   ))

--- a/stories/themes.ts
+++ b/stories/themes.ts
@@ -8,8 +8,6 @@ export const themes: Record<string, PartialTheme> = {
         main: '#6185d0',
         contrastText: '#000',
       },
-      evenCellBg: '#000',
-      oddCellBg: '#000',
       gray: {
         '100': '#333',
         '200': '#666',
@@ -25,8 +23,6 @@ export const themes: Record<string, PartialTheme> = {
         main: '#4caf50',
         contrastText: '#fff',
       },
-      evenCellBg: '#fff',
-      oddCellBg: '#fff',
     },
     eventCellOverlappings: [
       {
@@ -45,8 +41,6 @@ export const themes: Record<string, PartialTheme> = {
         main: '#4caf50',
         contrastText: '#fff',
       },
-      evenCellBg: '#f1f1f1',
-      oddCellBg: '#fff',
     },
     eventCellOverlappings: [
       {


### PR DESCRIPTION
Hi **@acro5piano**

As per discussion, I did changes to ad the support to provide styles to calendar cells based on the date of the cell. For this, I have to remove evenCellBg and oddCellBg.

I introduces 2 new props `calendarCellStyle` and `calendarCellTextStyle`.

```
`calendarCellStyle`: Use this prop to provide custom styles to calendar cells based on date of cell.
calendarCellStyle = ViewStyle | (date: dayjs.Dayjs, hourRowIndex?: Number | undefined) => ViewStyle)
```

```
`calendarCellTextStyle` : Use this prop to provide custom styles to calendar cells text for Month mode. It is needed if have text color of cell visible based on date
calendarCellTextStyle = ViewStyle | (date: dayjs.Dayjs, hourRowIndex?: Number | undefined) => ViewStyle)
```

Note: `hourRowIndex` can be used to give background color to even cell and odd cells.

I have added 4 stories in mobile mode to demo the same.
1. Month - Calendar Cell Style
2. Month - Event Cell - Even and Odd Row BgColor
3. Week - Calendar Cell Style
4. Week - Calendar Cell - Even and Odd Row BgColor

**@acro5piano** Please review the changes and let me know of any further changes.

PS: `yarn build` and `yarn test` both run successfully.