### PR TITLE
add onPressDateHeader for month view

### DIFF
--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -29,6 +29,7 @@ interface CalendarBodyForMonthViewProps<T extends ICalendarEventBase> {
   calendarCellTextStyle?: CalendarCellTextStyle
   hideNowIndicator?: boolean
   onPressCell?: (date: Date) => void
+  onPressDateHeader?: (date: Date) => void
   onPressEvent?: (event: T) => void
   onSwipeHorizontal?: (d: HorizontalDirection) => void
   renderEvent?: EventRenderer<T>
@@ -42,6 +43,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
   targetDate,
   style,
   onPressCell,
+  onPressDateHeader,
   events,
   onPressEvent,
   eventCellStyle,
@@ -131,23 +133,32 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                 ]}
                 key={ii}
               >
-                <Text
-                  style={[
-                    { textAlign: 'center' },
-                    theme.typography.sm,
-                    {
-                      color:
-                        date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
-                          ? theme.palette.primary.main
-                          : theme.palette.gray['800'],
-                    },
-                    {
-                      ...getCalendarCellTextStyle(date?.toDate(), i),
-                    },
-                  ]}
+                <TouchableOpacity
+                  onPress={() =>
+                    date &&
+                    (onPressDateHeader
+                      ? onPressDateHeader(date.toDate())
+                      : onPressCell && onPressCell(date.toDate()))
+                  }
                 >
-                  {date && date.format('D')}
-                </Text>
+                  <Text
+                    style={[
+                      { textAlign: 'center' },
+                      theme.typography.sm,
+                      {
+                        color:
+                          date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
+                            ? theme.palette.primary.main
+                            : theme.palette.gray['800'],
+                      },
+                      {
+                        ...getCalendarCellTextStyle(date?.toDate(), i),
+                      },
+                    ]}
+                  >
+                    {date && date.format('D')}
+                  </Text>
+                </TouchableOpacity>
                 {date &&
                   events
                     .sort((a, b) => {

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -229,6 +229,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
           weekStartsOn={weekStartsOn}
           hideNowIndicator={hideNowIndicator}
           onPressCell={onPressCell}
+          onPressDateHeader={onPressDateHeader}
           onPressEvent={onPressEvent}
           onSwipeHorizontal={onSwipeHorizontal}
           renderEvent={renderEvent}


### PR DESCRIPTION
Added a way to have a callback for pressing the date in the cell of a month view.
I used `onPressDateHeader` in order to not have to add a new prop since it's the same usage, if you want a new one I will change it.
Falls back to `onPressCell` when not provided.