### PR TITLE
Show adjacent months dates on month view

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -189,6 +189,7 @@ describe('spanning events', () => {
       date,
       date.day(),
       0,
+      true,
     )
 
     expect(isMultipleDays).toBe(true)
@@ -202,6 +203,7 @@ describe('spanning events', () => {
       date,
       date.day(),
       0,
+      true,
     )
 
     expect(isMultipleDays).toBe(true)
@@ -216,6 +218,7 @@ describe('spanning events', () => {
       date,
       date.day(),
       0,
+      true,
     )
 
     expect(isMultipleDays).toBe(true)

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -18,6 +18,7 @@ import {
 import { useTheme } from '../theme/ThemeContext'
 import { typedMemo } from '../utils'
 import { CalendarEventForMonthView } from './CalendarEventForMonthView'
+import { getWeeksWithAdjacentMonths } from '..'
 
 interface CalendarBodyForMonthViewProps<T extends ICalendarEventBase> {
   containerHeight: number
@@ -28,6 +29,7 @@ interface CalendarBodyForMonthViewProps<T extends ICalendarEventBase> {
   calendarCellStyle?: CalendarCellStyle
   calendarCellTextStyle?: CalendarCellTextStyle
   hideNowIndicator?: boolean
+  showAdjacentMonths: boolean
   onPressCell?: (date: Date) => void
   onPressDateHeader?: (date: Date) => void
   onPressEvent?: (event: T) => void
@@ -51,6 +53,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
   calendarCellTextStyle,
   onSwipeHorizontal,
   hideNowIndicator,
+  showAdjacentMonths,
   renderEvent,
   maxVisibleEventCount,
   weekStartsOn,
@@ -63,7 +66,9 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
     onSwipeHorizontal,
   })
 
-  const weeks = calendarize(targetDate.toDate(), weekStartsOn)
+  const weeks = showAdjacentMonths
+    ? getWeeksWithAdjacentMonths(targetDate, weekStartsOn)
+    : calendarize(targetDate.toDate(), weekStartsOn)
 
   const minCellHeight = containerHeight / 5 - 30
   const theme = useTheme()
@@ -112,7 +117,9 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
           ]}
         >
           {week
-            .map((d) => (d > 0 ? targetDate.date(d) : null))
+            .map((d) =>
+              showAdjacentMonths ? targetDate.date(d) : d > 0 ? targetDate.date(d) : null,
+            )
             .map((date, ii) => (
               <TouchableOpacity
                 onPress={() => date && onPressCell && onPressCell(date.toDate())}
@@ -149,6 +156,8 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                         color:
                           date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
                             ? theme.palette.primary.main
+                            : date?.month() !== targetDate.month()
+                            ? theme.palette.gray['500']
                             : theme.palette.gray['800'],
                       },
                       {
@@ -199,6 +208,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                             calendarWidth={calendarWidth}
                             isRTL={theme.isRTL}
                             eventMinHeightForMonthView={eventMinHeightForMonthView}
+                            showAdjacentMonths={showAdjacentMonths}
                           />
                         ),
                       ],

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -29,6 +29,7 @@ interface CalendarBodyForMonthViewProps<T extends ICalendarEventBase> {
   calendarCellTextStyle?: CalendarCellTextStyle
   hideNowIndicator?: boolean
   onPressCell?: (date: Date) => void
+  onPressDateHeader?: (date: Date) => void
   onPressEvent?: (event: T) => void
   onSwipeHorizontal?: (d: HorizontalDirection) => void
   renderEvent?: EventRenderer<T>
@@ -42,6 +43,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
   targetDate,
   style,
   onPressCell,
+  onPressDateHeader,
   events,
   onPressEvent,
   eventCellStyle,
@@ -131,23 +133,32 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                 ]}
                 key={ii}
               >
-                <Text
-                  style={[
-                    { textAlign: 'center' },
-                    theme.typography.sm,
-                    {
-                      color:
-                        date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
-                          ? theme.palette.primary.main
-                          : theme.palette.gray['800'],
-                    },
-                    {
-                      ...getCalendarCellTextStyle(date?.toDate(), i),
-                    },
-                  ]}
+                <TouchableOpacity
+                  onPress={() =>
+                    date &&
+                    (onPressDateHeader
+                      ? onPressDateHeader(date.toDate())
+                      : onPressCell && onPressCell(date.toDate()))
+                  }
                 >
-                  {date && date.format('D')}
-                </Text>
+                  <Text
+                    style={[
+                      { textAlign: 'center' },
+                      theme.typography.sm,
+                      {
+                        color:
+                          date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
+                            ? theme.palette.primary.main
+                            : theme.palette.gray['800'],
+                      },
+                      {
+                        ...getCalendarCellTextStyle(date?.toDate(), i),
+                      },
+                    ]}
+                  >
+                    {date && date.format('D')}
+                  </Text>
+                </TouchableOpacity>
                 {date &&
                   events
                     .sort((a, b) => {

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -229,6 +229,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
           weekStartsOn={weekStartsOn}
           hideNowIndicator={hideNowIndicator}
           onPressCell={onPressCell}
+          onPressDateHeader={onPressDateHeader}
           onPressEvent={onPressEvent}
           onSwipeHorizontal={onSwipeHorizontal}
           renderEvent={renderEvent}

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -74,6 +74,7 @@ export interface CalendarContainerProps<T extends ICalendarEventBase> {
   date?: Date
   locale?: string
   hideNowIndicator?: boolean
+  showAdjacentMonths?: boolean
   mode?: Mode
   scrollOffsetMinutes?: number
   showTime?: boolean
@@ -105,6 +106,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
   calendarCellTextStyle,
   locale = 'en',
   hideNowIndicator = false,
+  showAdjacentMonths = false,
   mode = 'week',
   overlapOffset,
   scrollOffsetMinutes = 0,
@@ -228,6 +230,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
           calendarCellTextStyle={calendarCellTextStyle}
           weekStartsOn={weekStartsOn}
           hideNowIndicator={hideNowIndicator}
+          showAdjacentMonths={showAdjacentMonths}
           onPressCell={onPressCell}
           onPressDateHeader={onPressDateHeader}
           onPressEvent={onPressEvent}

--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -18,6 +18,7 @@ interface CalendarEventProps<T extends ICalendarEventBase> {
   calendarWidth: number
   isRTL: boolean
   eventMinHeightForMonthView: number
+  showAdjacentMonths: boolean
 }
 
 function _CalendarEventForMonthView<T extends ICalendarEventBase>({
@@ -30,12 +31,13 @@ function _CalendarEventForMonthView<T extends ICalendarEventBase>({
   calendarWidth,
   isRTL,
   eventMinHeightForMonthView,
+  showAdjacentMonths,
 }: CalendarEventProps<T>) {
   const theme = useTheme()
 
   const { eventWidth, isMultipleDays, isMultipleDaysStart, eventWeekDuration } = React.useMemo(
-    () => getEventSpanningInfo(event, date, dayOfTheWeek, calendarWidth),
-    [date, dayOfTheWeek, event, calendarWidth],
+    () => getEventSpanningInfo(event, date, dayOfTheWeek, calendarWidth, showAdjacentMonths),
+    [date, dayOfTheWeek, event, calendarWidth, showAdjacentMonths],
   )
 
   const touchableOpacityProps = useCalendarTouchableOpacityProps({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -264,10 +264,10 @@ export function stringHasContent(string: string): boolean {
 
 export function getWeeksWithAdjacentMonths(targetDate: dayjs.Dayjs, weekStartsOn: WeekNum) {
   let weeks = calendarize(targetDate.toDate(), weekStartsOn)
-
   const firstDayIndex = weeks[0].findIndex((d) => d === 1)
   const lastDay = targetDate.endOf('month').date()
   const lastDayIndex = weeks[weeks.length - 1].findIndex((d) => d === lastDay)
+
   weeks = weeks.map((week, iw) => {
     return week.map((d, id) => {
       if (d !== 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import calendarize, { Week } from 'calendarize'
 import dayjs from 'dayjs'
 import React from 'react'
 import { TextStyle, ViewStyle } from 'react-native'
@@ -221,26 +222,32 @@ export function getEventSpanningInfo(
   date: dayjs.Dayjs,
   dayOfTheWeek: number,
   calendarWidth: number,
+  showAdjacentMonths: boolean,
 ) {
   const dayWidth = calendarWidth / 7
 
   // adding + 1 because durations start at 0
-  const eventDuration = dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).days() + 1
-  const eventDaysLeft = dayjs.duration(dayjs(event.end).diff(date)).days() + 1
+  const eventDuration =
+    Math.floor(dayjs.duration(dayjs(event.end).diff(dayjs(event.start))).asDays()) + 1
+  const eventDaysLeft = Math.floor(dayjs.duration(dayjs(event.end).diff(date)).asDays()) + 1
   const weekDaysLeft = 7 - dayOfTheWeek
+  const monthDaysLeft = date.endOf('month').date() - date.date()
+  // console.log(dayOfTheWeek === 0 && !showAdjacentMonths && monthDaysLeft < 7)
   const isMultipleDays = eventDuration > 1
   // This is to determine how many days from the event to show during a week
   const eventWeekDuration =
-    eventDuration > weekDaysLeft
+    !showAdjacentMonths && monthDaysLeft < 7 && monthDaysLeft < eventDuration
+      ? monthDaysLeft + 1
+      : eventDuration > weekDaysLeft
       ? weekDaysLeft
-      : dayOfTheWeek === 0 && eventDaysLeft < eventDuration
+      : eventDaysLeft < eventDuration
       ? eventDaysLeft
       : eventDuration
   const isMultipleDaysStart =
     isMultipleDays &&
     (date.isSame(event.start, 'day') ||
       (dayOfTheWeek === 0 && date.isAfter(event.start)) ||
-      date.get('date') === 1)
+      (!showAdjacentMonths && date.get('date') === 1))
   // - 6 to take in account the padding
   const eventWidth = dayWidth * eventWeekDuration - 6
 
@@ -253,4 +260,25 @@ export function objHasContent(obj: ViewStyle | TextStyle): boolean {
 
 export function stringHasContent(string: string): boolean {
   return !!string.length
+}
+
+export function getWeeksWithAdjacentMonths(targetDate: dayjs.Dayjs, weekStartsOn: WeekNum) {
+  let weeks = calendarize(targetDate.toDate(), weekStartsOn)
+
+  const firstDayIndex = weeks[0].findIndex((d) => d === 1)
+  const lastDay = targetDate.endOf('month').date()
+  const lastDayIndex = weeks[weeks.length - 1].findIndex((d) => d === lastDay)
+  weeks = weeks.map((week, iw) => {
+    return week.map((d, id) => {
+      if (d !== 0) {
+        return d
+      } else if (iw === 0) {
+        return d - (firstDayIndex - id - 1)
+      } else {
+        return lastDay + (id - lastDayIndex)
+      }
+    }) as Week
+  })
+
+  return weeks
 }

--- a/stories/desktop.stories.tsx
+++ b/stories/desktop.stories.tsx
@@ -124,6 +124,21 @@ storiesOf('showcase - Desktop', module)
       </View>
     )
   })
+  .add('Month mode - Spanning Events (show adjacent months dates)', () => {
+    const state = useEvents(spanningEvents)
+    return (
+      <View style={styles.desktop}>
+        <Calendar
+          mode="month"
+          height={SCREEN_HEIGHT}
+          events={state.events}
+          onPressEvent={(event) => alert(event.title)}
+          onPressCell={state.addEvent}
+          showAdjacentMonths
+        />
+      </View>
+    )
+  })
   .add('event cell style', () => (
     <View style={styles.desktop}>
       <Calendar

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -83,6 +83,11 @@ export const spanningEvents: Array<ICalendarEventBase & { color?: string }> = [
     start: dayjs().add(1, 'day').set('hour', 7).set('minute', 45).toDate(),
     end: dayjs().add(4, 'day').set('hour', 13).set('minute', 30).toDate(),
   },
+  {
+    title: 'Vacation',
+    start: dayjs().subtract(1, 'month').set('hour', 7).set('minute', 45).toDate(),
+    end: dayjs().add(1, 'month').set('hour', 13).set('minute', 30).toDate(),
+  },
 ]
 
 export interface MyCustomEventType extends ICalendarEventBase {


### PR DESCRIPTION
Added a prop to show adjacent months dates.

I used `dayjs.date()` property `If the range is exceeded, it will bubble up to the months.` to repopulate `weeks` replacing `calendarize`'s zeros to extend the range.

I also fixed event spanning to fit the property.

Let me know what you think!