### PR TITLE
Fix month view swipe back

### DIFF
--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -29,6 +29,7 @@ interface CalendarBodyForMonthViewProps<T extends ICalendarEventBase> {
   calendarCellTextStyle?: CalendarCellTextStyle
   hideNowIndicator?: boolean
   onPressCell?: (date: Date) => void
+  onPressDateHeader?: (date: Date) => void
   onPressEvent?: (event: T) => void
   onSwipeHorizontal?: (d: HorizontalDirection) => void
   renderEvent?: EventRenderer<T>
@@ -42,6 +43,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
   targetDate,
   style,
   onPressCell,
+  onPressDateHeader,
   events,
   onPressEvent,
   eventCellStyle,
@@ -131,23 +133,32 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                 ]}
                 key={ii}
               >
-                <Text
-                  style={[
-                    { textAlign: 'center' },
-                    theme.typography.sm,
-                    {
-                      color:
-                        date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
-                          ? theme.palette.primary.main
-                          : theme.palette.gray['800'],
-                    },
-                    {
-                      ...getCalendarCellTextStyle(date?.toDate(), i),
-                    },
-                  ]}
+                <TouchableOpacity
+                  onPress={() =>
+                    date &&
+                    (onPressDateHeader
+                      ? onPressDateHeader(date.toDate())
+                      : onPressCell && onPressCell(date.toDate()))
+                  }
                 >
-                  {date && date.format('D')}
-                </Text>
+                  <Text
+                    style={[
+                      { textAlign: 'center' },
+                      theme.typography.sm,
+                      {
+                        color:
+                          date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
+                            ? theme.palette.primary.main
+                            : theme.palette.gray['800'],
+                      },
+                      {
+                        ...getCalendarCellTextStyle(date?.toDate(), i),
+                      },
+                    ]}
+                  >
+                    {date && date.format('D')}
+                  </Text>
+                </TouchableOpacity>
                 {date &&
                   events
                     .sort((a, b) => {

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -229,6 +229,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
           weekStartsOn={weekStartsOn}
           hideNowIndicator={hideNowIndicator}
           onPressCell={onPressCell}
+          onPressDateHeader={onPressDateHeader}
           onPressEvent={onPressEvent}
           onSwipeHorizontal={onSwipeHorizontal}
           renderEvent={renderEvent}

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -191,7 +191,11 @@ function _CalendarContainer<T extends ICalendarEventBase>({
       if ((direction === 'LEFT' && !theme.isRTL) || (direction === 'RIGHT' && theme.isRTL)) {
         setTargetDate(targetDate.add(modeToNum(mode, targetDate), 'day'))
       } else {
-        setTargetDate(targetDate.add(modeToNum(mode, targetDate) * -1, 'day'))
+        if (mode === 'month') {
+          setTargetDate(targetDate.add(targetDate.date() * -1, 'day'))
+        } else {
+          setTargetDate(targetDate.add(modeToNum(mode, targetDate) * -1, 'day'))
+        }
       }
     },
     [swipeEnabled, targetDate, mode, theme.isRTL],


### PR DESCRIPTION
I found out that swipe back to February had a bug and would jump to January and looking into it I actually found in `full-customization.stories.tsx` that the code to move to the previous date on month mode was different so I fixed it using this.