### PR TITLE
Optional Event ordering prop feature to improve performance of week/day view

### DIFF
--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -55,6 +55,7 @@ interface CalendarBodyProps<T extends ICalendarEventBase> {
   headerComponentStyle?: ViewStyle
   hourStyle?: TextStyle
   hideHours?: Boolean
+  isEventOrderingEnabled?: boolean
 }
 
 function _CalendarBody<T extends ICalendarEventBase>({
@@ -78,6 +79,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
   headerComponentStyle = {},
   hourStyle = {},
   hideHours = false,
+  isEventOrderingEnabled = true,
 }: CalendarBodyProps<T>) {
   const scrollView = React.useRef<ScrollView>(null)
   const { now } = useNow(!hideNowIndicator)
@@ -126,15 +128,24 @@ function _CalendarBody<T extends ICalendarEventBase>({
           onPressEvent={onPressEvent}
           eventCellStyle={eventCellStyle}
           showTime={showTime}
-          eventCount={getCountOfEventsAtEvent(event, events)}
-          eventOrder={getOrderOfEvent(event, events)}
+          eventCount={isEventOrderingEnabled ? getCountOfEventsAtEvent(event, events) : undefined}
+          eventOrder={isEventOrderingEnabled ? getOrderOfEvent(event, events) : undefined}
           overlapOffset={overlapOffset}
           renderEvent={renderEvent}
           ampm={ampm}
         />
       )
     },
-    [ampm, eventCellStyle, events, onPressEvent, overlapOffset, renderEvent, showTime],
+    [
+      ampm,
+      eventCellStyle,
+      events,
+      isEventOrderingEnabled,
+      onPressEvent,
+      overlapOffset,
+      renderEvent,
+      showTime,
+    ],
   )
 
   const theme = useTheme()

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -99,6 +99,7 @@ export interface CalendarContainerProps<T extends ICalendarEventBase> {
   showAllDayEventCell?: boolean
   sortedMonthView?: boolean
   moreLabel?: string
+  isEventOrderingEnabled?: boolean
 }
 
 function _CalendarContainer<T extends ICalendarEventBase>({
@@ -143,6 +144,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
   showAdjacentMonths = true,
   sortedMonthView = true,
   hideHours = false,
+  isEventOrderingEnabled,
 }: CalendarContainerProps<T>) {
   const [targetDate, setTargetDate] = React.useState(dayjs(date))
 
@@ -298,6 +300,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
         headerComponent={headerComponent}
         headerComponentStyle={headerComponentStyle}
         hourStyle={hourStyle}
+        isEventOrderingEnabled={isEventOrderingEnabled}
       />
     </React.Fragment>
   )


### PR DESCRIPTION
--added prop to Calendar component to make event Ordering in week/day view an optional feature
 --this will improve the plugin performance considerably(10+ events) if one doesn't want this feature or wish to handle it separately in their own wrapper component.
Regarding #820 