### PR TITLE
Fixed accidently changed API behavior

### DIFF
--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -94,7 +94,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
 
   const sortedEvents = React.useCallback(
     (day: dayjs.Dayjs) => {
-      if (sortedMonthView) {
+      if (!sortedMonthView) {
         return events.filter(({ start, end }) =>
           day.isBetween(dayjs(start).startOf('day'), dayjs(end).endOf('day'), null, '[)'),
         )


### PR DESCRIPTION
In this [PR](https://github.com/acro5piano/react-native-big-calendar/pull/892) , it seems that the behavior of `sortedMonthView` is accidently changed.

Before that PR, sorting logic is executed when sortedMonthView is true, but after it, sorting logic is run when sortedMonthView is false.

I thought that this could be misleading. So I fixed it.

[Before](https://github.com/acro5piano/react-native-big-calendar/pull/892/files#diff-09273721dcf5e4cfcef5b2c49d609294814ff7e89e5bada20461ad8907f2f54aL108-L109) and [After](https://github.com/acro5piano/react-native-big-calendar/pull/892/files#diff-09273721dcf5e4cfcef5b2c49d609294814ff7e89e5bada20461ad8907f2f54aR95-R98).
They are reversed.