### PR TITLE
feat: add prop to use new improved algorithm to create overlapping groups

### DIFF
--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -14,8 +14,8 @@ import {
 } from '../interfaces'
 import { useTheme } from '../theme/ThemeContext'
 import {
+  enrichEvents,
   getCountOfEventsAtEvent,
-  getOrderOfEvent,
   getRelativeTopInDay,
   hours,
   isToday,
@@ -24,6 +24,8 @@ import { typedMemo } from '../utils/react'
 import { CalendarEvent } from './CalendarEvent'
 import { HourGuideCell } from './HourGuideCell'
 import { HourGuideColumn } from './HourGuideColumn'
+import { useMemo } from 'react'
+import { getOrderOfEvent } from '../../build'
 
 const styles = StyleSheet.create({
   nowIndicator: {
@@ -58,6 +60,8 @@ interface CalendarBodyProps<T extends ICalendarEventBase> {
   hideHours?: Boolean
   isEventOrderingEnabled?: boolean
   showVerticalScrollIndicator?: boolean
+  useEnrichedEvents?: boolean
+  eventsAreSorted?: boolean
 }
 
 function _CalendarBody<T extends ICalendarEventBase>({
@@ -84,6 +88,8 @@ function _CalendarBody<T extends ICalendarEventBase>({
   hideHours = false,
   isEventOrderingEnabled = true,
   showVerticalScrollIndicator = false,
+  useEnrichedEvents = false,
+  eventsAreSorted = false,
 }: CalendarBodyProps<T>) {
   const scrollView = React.useRef<ScrollView>(null)
   const { now } = useNow(!hideNowIndicator)
@@ -130,6 +136,21 @@ function _CalendarBody<T extends ICalendarEventBase>({
     [onLongPressCell],
   )
 
+  const enrichedEvents = useMemo(() => {
+    if (useEnrichedEvents) {
+      return enrichEvents(events, eventsAreSorted)
+    }
+    if (isEventOrderingEnabled) {
+      return events.map((event) => ({
+        ...event,
+        overlapPosition: getOrderOfEvent(event, events),
+        overlapCount: getCountOfEventsAtEvent(event, events),
+      }))
+    }
+
+    return events
+  }, [events, eventsAreSorted, isEventOrderingEnabled, useEnrichedEvents])
+
   const _renderMappedEvent = React.useCallback(
     (event: T, index: number) => {
       return (
@@ -139,24 +160,15 @@ function _CalendarBody<T extends ICalendarEventBase>({
           onPressEvent={onPressEvent}
           eventCellStyle={eventCellStyle}
           showTime={showTime}
-          eventCount={isEventOrderingEnabled ? getCountOfEventsAtEvent(event, events) : undefined}
-          eventOrder={isEventOrderingEnabled ? getOrderOfEvent(event, events) : undefined}
+          eventCount={event.overlapCount}
+          eventOrder={event.overlapPosition}
           overlapOffset={overlapOffset}
           renderEvent={renderEvent}
           ampm={ampm}
         />
       )
     },
-    [
-      ampm,
-      eventCellStyle,
-      events,
-      isEventOrderingEnabled,
-      onPressEvent,
-      overlapOffset,
-      renderEvent,
-      showTime,
-    ],
+    [ampm, eventCellStyle, onPressEvent, overlapOffset, renderEvent, showTime],
   )
 
   const theme = useTheme()
@@ -214,7 +226,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
               {/* Render events of this date */}
               {/* M  T  (W)  T  F  S  S */}
               {/*       S-E             */}
-              {events
+              {(enrichedEvents as T[])
                 .filter(({ start }) =>
                   dayjs(start).isBetween(date.startOf('day'), date.endOf('day'), null, '[)'),
                 )
@@ -223,7 +235,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
               {/* Render events which starts before this date and ends on this date */}
               {/* M  T  (W)  T  F  S  S */}
               {/* S------E              */}
-              {events
+              {(enrichedEvents as T[])
                 .filter(
                   ({ start, end }) =>
                     dayjs(start).isBefore(date.startOf('day')) &&
@@ -238,7 +250,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
               {/* Render events which starts before this date and ends after this date */}
               {/* M  T  (W)  T  F  S  S */}
               {/*    S-------E          */}
-              {events
+              {(enrichedEvents as T[])
                 .filter(
                   ({ start, end }) =>
                     dayjs(start).isBefore(date.startOf('day')) &&

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -109,6 +109,18 @@ export interface CalendarContainerProps<T extends ICalendarEventBase> {
   disableMonthEventCellPress?: boolean
   showVerticalScrollIndicator?: boolean
   itemSeparatorComponent?: React.ComponentType<any> | null | undefined
+  /**
+   * If true, the events will be enriched with the following properties:
+   * - `overlapPosition`: position of the event in the stack of overlapping events
+   * Default value is `false`.
+   */
+  useEnrichedEvents?: boolean
+  /**
+   * If true, skip the sorting of events improving the performance.
+   * This parameter is ignored if `useEnrichedEvents` is `false`.
+   * Default value is `false`.
+   */
+  eventsAreSorted?: boolean
 }
 
 function _CalendarContainer<T extends ICalendarEventBase>({
@@ -160,6 +172,8 @@ function _CalendarContainer<T extends ICalendarEventBase>({
   disableMonthEventCellPress = false,
   showVerticalScrollIndicator = false,
   itemSeparatorComponent = null,
+  useEnrichedEvents = false,
+  eventsAreSorted = false,
 }: CalendarContainerProps<T>) {
   const [targetDate, setTargetDate] = React.useState(dayjs(date))
 
@@ -353,6 +367,8 @@ function _CalendarContainer<T extends ICalendarEventBase>({
         hourStyle={hourStyle}
         isEventOrderingEnabled={isEventOrderingEnabled}
         showVerticalScrollIndicator={showVerticalScrollIndicator}
+        useEnrichedEvents={useEnrichedEvents}
+        eventsAreSorted={eventsAreSorted}
       />
     </React.Fragment>
   )

--- a/src/components/CalendarEvent.tsx
+++ b/src/components/CalendarEvent.tsx
@@ -70,7 +70,6 @@ function _CalendarEvent<T extends ICalendarEventBase>({
     const fgColors = palettes.map((p) => p.contrastText)
     return fgColors[eventCount % fgColors.length] || fgColors[0]
   }, [eventCount, palettes])
-
   if (renderEvent) {
     return renderEvent(event, touchableOpacityProps)
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,14 @@ export interface ICalendarEventBase {
   children?: ReactElement | null
   hideHours?: boolean
   disabled?: boolean
+  /**
+   * overlapping position of event starting from 0 (optional)
+   */
+  overlapPosition?: number
+  /**
+   * number of events overlapping with this event (optional)
+   */
+  overlapCount?: number
 }
 
 export type CalendarTouchableOpacityProps = {

--- a/src/utils/__tests__/datetime.test.ts
+++ b/src/utils/__tests__/datetime.test.ts
@@ -6,6 +6,7 @@ import * as R from 'remeda'
 
 import { ICalendarEventBase } from '../../interfaces'
 import * as utils from '../datetime'
+import { enrichEvents } from '../datetime'
 
 Mockdate.set('2021-09-17T04:00:00.000Z')
 
@@ -58,6 +59,13 @@ const events: ICalendarEventBase[] = [
   start: e.start.toDate(),
   end: e.end.toDate(),
 }))
+
+const getEvents = (eventsHours: { startHour: number; endHour: number }[]): ICalendarEventBase[] =>
+  eventsHours.map(({ startHour, endHour }) => ({
+    title: `Meeting from ${startHour} to ${endHour}`,
+    start: dayjs().set('hour', startHour).set('minute', 0).toDate(),
+    end: dayjs().set('hour', endHour).set('minute', 0).toDate(),
+  }))
 
 function assertDateRange(expected: any[], actual: any[]) {
   const formatToIso = (a: any) => a.toISOString()
@@ -224,5 +232,161 @@ describe('spanning events', () => {
     expect(isMultipleDays).toBe(true)
     expect(isMultipleDaysStart).toBe(true)
     expect(eventWeekDuration).toBe(6)
+  })
+})
+
+describe('enrichEvents', () => {
+  test('should add positions and overlap counts to sorted events when ends with a single group', () => {
+    const eventsWithOverlaps = getEvents([
+      { startHour: 1, endHour: 3 },
+      { startHour: 1, endHour: 5 },
+      { startHour: 2, endHour: 4 },
+      { startHour: 4, endHour: 6 },
+      { startHour: 6, endHour: 8 },
+      { startHour: 7, endHour: 8 },
+      { startHour: 8, endHour: 9 },
+    ])
+
+    const groups = enrichEvents(eventsWithOverlaps, true)
+
+    expect(groups).toEqual([
+      {
+        ...eventsWithOverlaps[0],
+        overlapPosition: 0,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[1],
+        overlapPosition: 1,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[2],
+        overlapPosition: 2,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[3],
+        overlapPosition: 3,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[4],
+        overlapPosition: 0,
+        overlapCount: 2,
+      },
+      {
+        ...eventsWithOverlaps[5],
+        overlapPosition: 1,
+        overlapCount: 2,
+      },
+      {
+        ...eventsWithOverlaps[6],
+        overlapPosition: 0,
+        overlapCount: 1,
+      },
+    ])
+  })
+  test('should add positions and overlap counts to sorted events when ends with a overlapping group', () => {
+    const eventsWithOverlaps = getEvents([
+      { startHour: 1, endHour: 3 },
+      { startHour: 1, endHour: 5 },
+      { startHour: 2, endHour: 4 },
+      { startHour: 4, endHour: 6 },
+      { startHour: 6, endHour: 8 },
+      { startHour: 7, endHour: 8 },
+      { startHour: 7, endHour: 9 },
+    ])
+
+    const groups = enrichEvents(eventsWithOverlaps, true)
+
+    expect(groups).toEqual([
+      {
+        ...eventsWithOverlaps[0],
+        overlapPosition: 0,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[1],
+        overlapPosition: 1,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[2],
+        overlapPosition: 2,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[3],
+        overlapPosition: 3,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[4],
+        overlapPosition: 0,
+        overlapCount: 3,
+      },
+      {
+        ...eventsWithOverlaps[5],
+        overlapPosition: 1,
+        overlapCount: 3,
+      },
+      {
+        ...eventsWithOverlaps[6],
+        overlapPosition: 2,
+        overlapCount: 3,
+      },
+    ])
+  })
+  test('should add positions to non-sorted events', () => {
+    const eventsWithOverlaps = getEvents([
+      { startHour: 1, endHour: 3 },
+      { startHour: 6, endHour: 8 },
+      { startHour: 2, endHour: 4 },
+      { startHour: 4, endHour: 6 },
+      { startHour: 8, endHour: 9 },
+      { startHour: 1, endHour: 5 },
+      { startHour: 7, endHour: 8 },
+    ])
+
+    const groups = enrichEvents(eventsWithOverlaps)
+
+    expect(groups).toEqual([
+      {
+        ...eventsWithOverlaps[0],
+        overlapPosition: 0,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[1],
+        overlapPosition: 1,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[2],
+        overlapPosition: 2,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[3],
+        overlapPosition: 3,
+        overlapCount: 4,
+      },
+      {
+        ...eventsWithOverlaps[4],
+        overlapPosition: 0,
+        overlapCount: 2,
+      },
+      {
+        ...eventsWithOverlaps[5],
+        overlapPosition: 1,
+        overlapCount: 2,
+      },
+      {
+        ...eventsWithOverlaps[6],
+        overlapPosition: 0,
+        overlapCount: 1,
+      },
+    ])
   })
 })

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -5,6 +5,10 @@ import { RecursiveArray, Text, TouchableOpacity, View, ViewStyle } from 'react-n
 import { EventRenderer, ICalendarEventBase } from '../src/interfaces'
 import { formatStartEnd } from '../src/utils/datetime'
 
+const getRandomInt = (min: number, max: number) => {
+  return Math.floor(Math.random() * (max - min)) + min
+}
+
 const eventNotes = (
   <View style={{ marginTop: 3 }}>
     <Text style={{ fontSize: 10, color: 'white' }}> Phone number: 555-123-4567 </Text>
@@ -56,6 +60,22 @@ export const events: Array<ICalendarEventBase & { color?: string }> = [
     children: eventNotes,
   },
 ]
+
+export const tonsOfEvents: Array<ICalendarEventBase & { color?: string }> = new Array(200)
+  .fill(undefined)
+  .map((_) => {
+    const startHour = getRandomInt(0, 23)
+    const endHour = getRandomInt(startHour + 1, 24)
+    const startMinute = getRandomInt(0, 59)
+    const endMinute = getRandomInt(0, 59)
+    return {
+      title: 'Watch Boxing',
+      start: dayjs().set('hour', startHour).set('minute', startMinute).set('second', 0).toDate(),
+      end: dayjs().set('hour', endHour).set('minute', endMinute).toDate(),
+    }
+  })
+
+export const tonsOfEventsSorted = tonsOfEvents.sort((a, b) => a.start.getTime() - b.start.getTime())
 
 export const spanningEvents: Array<ICalendarEventBase & { color?: string }> = [
   {

--- a/stories/mobile.stories.tsx
+++ b/stories/mobile.stories.tsx
@@ -5,7 +5,7 @@ import { Alert, Text, TouchableOpacity, View } from 'react-native'
 
 import { Calendar, EventRenderer } from '../src'
 import { AppHeader, HEADER_HEIGHT } from './components/AppHeader'
-import { events } from './events'
+import { events, tonsOfEvents, tonsOfEventsSorted } from './events'
 import { useEvents } from './hooks'
 import { styles } from './styles'
 
@@ -28,6 +28,28 @@ storiesOf('showcase - Mobile', module)
         events={events}
         mode="day"
         onPressEvent={(event) => alert(event.title)}
+      />
+    </View>
+  ))
+  .add('Tons of events', () => (
+    <View style={styles.mobile}>
+      <Calendar
+        height={MOBILE_HEIGHT}
+        events={tonsOfEvents}
+        mode="day"
+        onPressEvent={(event) => alert(event.title)}
+      />
+    </View>
+  ))
+  .add('Tons of sorted events', () => (
+    <View style={styles.mobile}>
+      <Calendar
+        height={MOBILE_HEIGHT}
+        events={tonsOfEventsSorted}
+        mode="day"
+        onPressEvent={(event) => alert(event.title)}
+        useEnrichedEvents
+        eventsAreSorted
       />
     </View>
   ))


### PR DESCRIPTION
Related to [this issue](https://github.com/wix/react-native-calendars/issues/2212)

# Changes

This PR has 2 main changes:

## Performance improvement to existing logic

When creating the overlapping groups, the library originally iterated over all the events, and for each iteration, it iterated over the entire list again, resulting in significant slowness as the number of events increased. I improved the process by moving the creation of overlapping groups into a useMemo function, which now iterates over the list just once.

## Add new algorithm to create overlapping groups in a more performant way

I introduced two new props:

- `useEnrichedEvents`: This flag enables the new algorithm to improve the performance when creating the overlapping groups
- `eventsAreSorted`: This flag allows for the skipping of event sorting, thereby improving performance. This is particularly useful when the host application already has the data sorted, as is the case when the backend returns it pre-sorted.

# Tests

## Storybook

I introduced a new story named "Tons of sorted events" that utilizes pre-sorted data alongside the updated algorithm. The rendering time has significantly improved compared to the current implementation.

## Unit Tests

Added unit tests to ensure the new algorithm work fine.


