### PR TITLE
fix: lib crashes when receiving empty events

### DIFF
--- a/src/utils/__tests__/datetime.test.ts
+++ b/src/utils/__tests__/datetime.test.ts
@@ -236,6 +236,11 @@ describe('spanning events', () => {
 })
 
 describe('enrichEvents', () => {
+  test('should return empty when gets empty', () => {
+    const events: ICalendarEventBase[] = []
+    const groups = enrichEvents(events)
+    expect(groups).toEqual([])
+  })
   test('should add positions and overlap counts to sorted events when ends with a single group', () => {
     const eventsWithOverlaps = getEvents([
       { startHour: 1, endHour: 3 },

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -162,6 +162,8 @@ export function enrichEvents(
   events: ICalendarEventBase[],
   eventsAreSorted?: boolean,
 ): ICalendarEventBase[] {
+  if (!events.length) return []
+
   let groupEndTime = events[0].end
   let overlapPosition = 0
   let overlapCounting = 0


### PR DESCRIPTION
Lib crashes when sending an empty events array using the new enrichedEvents function.

- Added a clause to return empty when receiving an empty array
- Added unit test