### PR TITLE
feat: create custom renderer to improve performance on bigger datasets

### DIFF
--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -24,7 +24,7 @@ import {
   WeekNum,
 } from '../interfaces'
 import { useTheme } from '../theme/ThemeContext'
-import { getWeeksWithAdjacentMonths } from '../utils/datetime'
+import { getWeeksWithAdjacentMonths, SIMPLE_DATE_FORMAT } from '../utils/datetime'
 import { typedMemo } from '../utils/react'
 import { CalendarEventForMonthView } from './CalendarEventForMonthView'
 
@@ -214,7 +214,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
           theme.typography.sm,
           {
             color:
-              date?.format('YYYY-MM-DD') === now.format('YYYY-MM-DD')
+              date?.format(SIMPLE_DATE_FORMAT) === now.format(SIMPLE_DATE_FORMAT)
                 ? theme.palette.primary.main
                 : date?.month() !== targetDate.month()
                 ? theme.palette.gray['500']

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -12,7 +12,12 @@ import { u } from '../commonStyles'
 import { useTheme } from '../theme/ThemeContext'
 import dayjs from 'dayjs'
 import { CalendarEvent } from './CalendarEvent'
-import { getCountOfEventsAtEvent, getOrderOfEvent, isToday } from '../utils/datetime'
+import {
+  getCountOfEventsAtEvent,
+  getOrderOfEvent,
+  isToday,
+  SIMPLE_DATE_FORMAT,
+} from '../utils/datetime'
 import { stringHasContent } from '../utils/object'
 
 interface ScheduleProps<T extends ICalendarEventBase> {
@@ -99,7 +104,7 @@ function _Schedule<T extends ICalendarEventBase>({
    */
   const getItem = React.useMemo(() => {
     const groupedData = events.reduce((result: any, item: T): any => {
-      const startDate = dayjs(item.start).format('YYYY-MM-DD')
+      const startDate = dayjs(item.start).format(SIMPLE_DATE_FORMAT)
       if (!result[startDate]) {
         result[startDate] = []
       }

--- a/src/utils/__tests__/datetime.test.ts
+++ b/src/utils/__tests__/datetime.test.ts
@@ -6,7 +6,7 @@ import * as R from 'remeda'
 
 import { ICalendarEventBase } from '../../interfaces'
 import * as utils from '../datetime'
-import { enrichEvents } from '../datetime'
+import { enrichEvents, SIMPLE_DATE_FORMAT } from '../datetime'
 
 Mockdate.set('2021-09-17T04:00:00.000Z')
 
@@ -239,7 +239,7 @@ describe('enrichEvents', () => {
   test('should return empty when gets empty', () => {
     const events: ICalendarEventBase[] = []
     const groups = enrichEvents(events)
-    expect(groups).toEqual([])
+    expect(groups).toEqual({})
   })
   test('should add positions and overlap counts to sorted events when ends with a single group', () => {
     const eventsWithOverlaps = getEvents([
@@ -254,43 +254,45 @@ describe('enrichEvents', () => {
 
     const groups = enrichEvents(eventsWithOverlaps, true)
 
-    expect(groups).toEqual([
-      {
-        ...eventsWithOverlaps[0],
-        overlapPosition: 0,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[1],
-        overlapPosition: 1,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[2],
-        overlapPosition: 2,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[3],
-        overlapPosition: 3,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[4],
-        overlapPosition: 0,
-        overlapCount: 2,
-      },
-      {
-        ...eventsWithOverlaps[5],
-        overlapPosition: 1,
-        overlapCount: 2,
-      },
-      {
-        ...eventsWithOverlaps[6],
-        overlapPosition: 0,
-        overlapCount: 1,
-      },
-    ])
+    expect(groups).toEqual({
+      [dayjs().format(SIMPLE_DATE_FORMAT)]: [
+        {
+          ...eventsWithOverlaps[0],
+          overlapPosition: 0,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[1],
+          overlapPosition: 1,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[2],
+          overlapPosition: 2,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[3],
+          overlapPosition: 3,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[4],
+          overlapPosition: 0,
+          overlapCount: 2,
+        },
+        {
+          ...eventsWithOverlaps[5],
+          overlapPosition: 1,
+          overlapCount: 2,
+        },
+        {
+          ...eventsWithOverlaps[6],
+          overlapPosition: 0,
+          overlapCount: 1,
+        },
+      ],
+    })
   })
   test('should add positions and overlap counts to sorted events when ends with a overlapping group', () => {
     const eventsWithOverlaps = getEvents([
@@ -305,43 +307,45 @@ describe('enrichEvents', () => {
 
     const groups = enrichEvents(eventsWithOverlaps, true)
 
-    expect(groups).toEqual([
-      {
-        ...eventsWithOverlaps[0],
-        overlapPosition: 0,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[1],
-        overlapPosition: 1,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[2],
-        overlapPosition: 2,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[3],
-        overlapPosition: 3,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[4],
-        overlapPosition: 0,
-        overlapCount: 3,
-      },
-      {
-        ...eventsWithOverlaps[5],
-        overlapPosition: 1,
-        overlapCount: 3,
-      },
-      {
-        ...eventsWithOverlaps[6],
-        overlapPosition: 2,
-        overlapCount: 3,
-      },
-    ])
+    expect(groups).toEqual({
+      [dayjs().format(SIMPLE_DATE_FORMAT)]: [
+        {
+          ...eventsWithOverlaps[0],
+          overlapPosition: 0,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[1],
+          overlapPosition: 1,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[2],
+          overlapPosition: 2,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[3],
+          overlapPosition: 3,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[4],
+          overlapPosition: 0,
+          overlapCount: 3,
+        },
+        {
+          ...eventsWithOverlaps[5],
+          overlapPosition: 1,
+          overlapCount: 3,
+        },
+        {
+          ...eventsWithOverlaps[6],
+          overlapPosition: 2,
+          overlapCount: 3,
+        },
+      ],
+    })
   })
   test('should add positions to non-sorted events', () => {
     const eventsWithOverlaps = getEvents([
@@ -356,42 +360,44 @@ describe('enrichEvents', () => {
 
     const groups = enrichEvents(eventsWithOverlaps)
 
-    expect(groups).toEqual([
-      {
-        ...eventsWithOverlaps[0],
-        overlapPosition: 0,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[1],
-        overlapPosition: 1,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[2],
-        overlapPosition: 2,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[3],
-        overlapPosition: 3,
-        overlapCount: 4,
-      },
-      {
-        ...eventsWithOverlaps[4],
-        overlapPosition: 0,
-        overlapCount: 2,
-      },
-      {
-        ...eventsWithOverlaps[5],
-        overlapPosition: 1,
-        overlapCount: 2,
-      },
-      {
-        ...eventsWithOverlaps[6],
-        overlapPosition: 0,
-        overlapCount: 1,
-      },
-    ])
+    expect(groups).toEqual({
+      [dayjs().format(SIMPLE_DATE_FORMAT)]: [
+        {
+          ...eventsWithOverlaps[0],
+          overlapPosition: 0,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[1],
+          overlapPosition: 1,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[2],
+          overlapPosition: 2,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[3],
+          overlapPosition: 3,
+          overlapCount: 4,
+        },
+        {
+          ...eventsWithOverlaps[4],
+          overlapPosition: 0,
+          overlapCount: 2,
+        },
+        {
+          ...eventsWithOverlaps[5],
+          overlapPosition: 1,
+          overlapCount: 2,
+        },
+        {
+          ...eventsWithOverlaps[6],
+          overlapPosition: 0,
+          overlapCount: 1,
+        },
+      ],
+    })
   })
 })

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -62,19 +62,37 @@ export const events: Array<ICalendarEventBase & { color?: string }> = [
   },
 ]
 
-export const tonsOfEvents: Array<ICalendarEventBase & { color?: string }> = new Array(200)
+export const tonsOfEvents: Array<ICalendarEventBase & { color?: string }> = new Array(10)
   .fill(undefined)
   .map((_) => {
+    const day = getRandomInt(dayjs().startOf('week').get('day'), dayjs().endOf('week').get('day'))
     const startHour = getRandomInt(0, 23)
-    const endHour = getRandomInt(startHour + 1, 24)
+    const endHour = getRandomInt(startHour + 2, 24)
     const startMinute = getRandomInt(0, 59)
     const endMinute = getRandomInt(0, 59)
     return {
       title: 'Watch Boxing',
-      start: dayjs().set('hour', startHour).set('minute', startMinute).set('second', 0).toDate(),
-      end: dayjs().set('hour', endHour).set('minute', endMinute).toDate(),
+      start: dayjs()
+        .set('day', day)
+        .set('hour', startHour)
+        .set('minute', startMinute)
+        .set('second', 0)
+        .toDate(),
+      end: dayjs()
+        .set('day', day)
+        .set('hour', endHour)
+        .set('minute', endMinute)
+        .set('second', 0)
+        .toDate(),
     }
   })
+
+// Add an event that spans multiple days
+tonsOfEvents.push({
+  title: 'Overlapping event',
+  start: dayjs().set('hour', 10).set('minute', 0).toDate(),
+  end: dayjs().set('hour', 10).set('minute', 0).add(1, 'day').toDate(),
+})
 
 export const tonsOfEventsSorted = tonsOfEvents.sort((a, b) => a.start.getTime() - b.start.getTime())
 

--- a/stories/mobile.stories.tsx
+++ b/stories/mobile.stories.tsx
@@ -31,28 +31,6 @@ storiesOf('showcase - Mobile', module)
       />
     </View>
   ))
-  .add('Tons of events', () => (
-    <View style={styles.mobile}>
-      <Calendar
-        height={MOBILE_HEIGHT}
-        events={tonsOfEvents}
-        mode="day"
-        onPressEvent={(event) => alert(event.title)}
-      />
-    </View>
-  ))
-  .add('Tons of sorted events', () => (
-    <View style={styles.mobile}>
-      <Calendar
-        height={MOBILE_HEIGHT}
-        events={tonsOfEventsSorted}
-        mode="day"
-        onPressEvent={(event) => alert(event.title)}
-        enableEnrichedEvents
-        eventsAreSorted
-      />
-    </View>
-  ))
   .add('3days mode', () => (
     <View style={styles.mobile}>
       <Calendar
@@ -66,6 +44,28 @@ storiesOf('showcase - Mobile', module)
   .add('week mode', () => (
     <View style={styles.mobile}>
       <Calendar hideHours height={MOBILE_HEIGHT} events={events} />
+    </View>
+  ))
+  .add('Tons of events', () => (
+    <View style={styles.mobile}>
+      <Calendar
+        height={MOBILE_HEIGHT}
+        events={tonsOfEvents}
+        mode="week"
+        onPressEvent={(event) => alert(event.title)}
+      />
+    </View>
+  ))
+  .add('Tons of sorted events', () => (
+    <View style={styles.mobile}>
+      <Calendar
+        height={MOBILE_HEIGHT}
+        events={tonsOfEventsSorted}
+        mode="week"
+        onPressEvent={(event) => alert(event.title)}
+        enableEnrichedEvents
+        eventsAreSorted
+      />
     </View>
   ))
   .add('Month mode', () => {


### PR DESCRIPTION
### Context

Recently I discovered we are having some issues on week mode when passing a larger dataset of events. This issue is caused due [HERE](https://github.com/acro5piano/react-native-big-calendar/blob/main/src/components/CalendarBody.tsx#L226-L264) we are filtering 3 times the event list in each re-render.

### Solution

Now when enabling the enrichedEvents through the prop `enableEnrichedEvents` the lib will be using a new way to organize and render the events:
1. Lib preprocess the events creating a dictionary where the key is the date of the event and the value is the event itself.
    a.  In case of multi-day events, the event will be duplicated (will be in all the keys from the start to the end date)
2. Lib renders the events inside a useCallback improving the performance on re-renders
3. we iterate just one time over the event list when rendering them

### Tests

####Storybook
I adjusted the story named "Tons of sorted events" to show week mode and show one multi-day event