### PR TITLE
feat: expose prop to be able to send the enriched dictionary

### DIFF
--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -61,6 +61,7 @@ interface CalendarBodyProps<T extends ICalendarEventBase> {
   hideHours?: Boolean
   isEventOrderingEnabled?: boolean
   showVerticalScrollIndicator?: boolean
+  enrichedEventsByDate?: Record<string, T[]>
   enableEnrichedEvents?: boolean
   eventsAreSorted?: boolean
 }
@@ -89,6 +90,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
   hideHours = false,
   isEventOrderingEnabled = true,
   showVerticalScrollIndicator = false,
+  enrichedEventsByDate,
   enableEnrichedEvents = false,
   eventsAreSorted = false,
 }: CalendarBodyProps<T>) {
@@ -137,12 +139,12 @@ function _CalendarBody<T extends ICalendarEventBase>({
     [onLongPressCell],
   )
 
-  const enrichedEventsByDate = useMemo(() => {
+  const internalEnrichedEventsByDate = useMemo(() => {
     if (enableEnrichedEvents) {
-      return enrichEvents(events, eventsAreSorted)
+      return enrichedEventsByDate || enrichEvents(events, eventsAreSorted)
     }
     return {}
-  }, [enableEnrichedEvents, events, eventsAreSorted])
+  }, [enableEnrichedEvents, enrichedEventsByDate, events, eventsAreSorted])
 
   const enrichedEvents = useMemo(() => {
     if (enableEnrichedEvents) return []
@@ -181,7 +183,9 @@ function _CalendarBody<T extends ICalendarEventBase>({
   const _renderEvents = React.useCallback(
     (date) => {
       if (enableEnrichedEvents) {
-        return (enrichedEventsByDate[date.format(SIMPLE_DATE_FORMAT)] || []).map(_renderMappedEvent)
+        return (internalEnrichedEventsByDate[date.format(SIMPLE_DATE_FORMAT)] || []).map(
+          _renderMappedEvent,
+        )
       } else {
         return (
           <>
@@ -228,7 +232,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
         )
       }
     },
-    [_renderMappedEvent, enableEnrichedEvents, enrichedEvents, enrichedEventsByDate],
+    [_renderMappedEvent, enableEnrichedEvents, enrichedEvents, internalEnrichedEventsByDate],
   )
 
   const theme = useTheme()

--- a/src/components/CalendarContainer.tsx
+++ b/src/components/CalendarContainer.tsx
@@ -110,6 +110,10 @@ export interface CalendarContainerProps<T extends ICalendarEventBase> {
   showVerticalScrollIndicator?: boolean
   itemSeparatorComponent?: React.ComponentType<any> | null | undefined
   /**
+   * If provided, we will skip the internal process of building the enriched events by date dictionary.
+   */
+  enrichedEventsByDate?: Record<string, T[]>
+  /**
    * If true, the events will be enriched with the following properties:
    * - `overlapPosition`: position of the event in the stack of overlapping events
    * Default value is `false`.
@@ -172,6 +176,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
   disableMonthEventCellPress = false,
   showVerticalScrollIndicator = false,
   itemSeparatorComponent = null,
+  enrichedEventsByDate,
   enableEnrichedEvents = false,
   eventsAreSorted = false,
 }: CalendarContainerProps<T>) {
@@ -373,6 +378,7 @@ function _CalendarContainer<T extends ICalendarEventBase>({
         hourStyle={hourStyle}
         isEventOrderingEnabled={isEventOrderingEnabled}
         showVerticalScrollIndicator={showVerticalScrollIndicator}
+        enrichedEventsByDate={enrichedEventsByDate}
         enableEnrichedEvents={enableEnrichedEvents}
         eventsAreSorted={eventsAreSorted}
       />


### PR DESCRIPTION
### Context

We've implemented a mechanism to leverage an internally optimized algorithm along with a dictionary for more efficient event rendering. Nevertheless, there are instances when the host app prefers to construct this dictionary independently, such as when handling it within a background job.

### Solution

The library now exposes a prop to accept the enrichedEvents dictionary. When enableEnrichedEvents is activated, the library attempts to utilize this new property. If the dictionary is not provided, it gracefully falls back to constructing it internally.