### PR TITLE
fix: AllDaysEvent event cell color problem

### DIFF
--- a/src/components/CalendarHeader.tsx
+++ b/src/components/CalendarHeader.tsx
@@ -149,12 +149,13 @@ function _CalendarHeader<T extends ICalendarEventBase>({
                 ]}
               >
                 {allDayEvents.map((event, index) => {
+                  const bg: any = (event?.color) ? {backgroundColor: event.color} : primaryBg;
                   if (!dayjs(date).isBetween(event.start, event.end, 'day', '[]')) {
                     return null
                   }
                   return (
                     <TouchableOpacity
-                      style={[eventCellCss.style, primaryBg, u['mt-2']]}
+                      style={[eventCellCss.style, bg, u['mt-2']]}
                       key={index}
                       onPress={() => _onPressEvent(event)}
                     >

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,7 @@ export interface ICalendarEventBase {
   children?: ReactElement | null
   hideHours?: boolean
   disabled?: boolean
+  color?: string
   /**
    * overlapping position of event starting from 0 (optional)
    */


### PR DESCRIPTION
When custom background color was typed via EventCellStyle, if the event was an AllDaysEvents and covered more than one day, the entered color was not visible. The problem has been fixed.

issue; https://github.com/acro5piano/react-native-big-calendar/issues/995