### PR TITLE
Add locale property to CalendarHeaderProps interface

### DIFF
--- a/src/components/CalendarHeader.tsx
+++ b/src/components/CalendarHeader.tsx
@@ -12,6 +12,7 @@ import { typedMemo } from '../utils/react'
 export interface CalendarHeaderProps<T extends ICalendarEventBase> {
   dateRange: dayjs.Dayjs[]
   cellHeight: number
+  locale: string
   style: ViewStyle
   allDayEventCellStyle: ViewStyle | ((event: T) => ViewStyle)
   allDayEventCellTextColor: string


### PR DESCRIPTION
First of all, I would like to thank you for providing this component. We use it in our open source project, which is an app for our students.

I have added the locale property to the CalendarHeaderProps interface. In the _CalendarContainer component [(currently on line 377)](https://github.com/acro5piano/react-native-big-calendar/blob/main/src/components/CalendarContainer.tsx#L377) the locale value is stored in the headerProps constant. The headerProps constant is later transferred to the HeaderComponent component as properties. If a custom header renderer is programmed, the calendar transfers the desired language. In my humble opinion, this is good software design.

Unfortunately, you first have to read the code to recognize this fact, because the locale property is missing in the CalendarHeaderProps interface. Otherwise you could already recognize the transfer of the language in the CalendarHeaderProps interface.