### PR TITLE
Fix: Multi-day events hidden by background color

### DIFF
--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -269,8 +269,27 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
             {
               minHeight: minCellHeight,
             },
+            { position: 'relative' },
           ]}
         >
+          <View
+            style={[
+              { position: 'absolute', height: '100%', width: '100%' },
+              theme.isRTL ? u['flex-row-reverse'] : u['flex-row'],
+            ]}
+          >
+            {week
+              .map((d) =>
+                showAdjacentMonths ? targetDate.date(d) : d > 0 ? targetDate.date(d) : null,
+              )
+              .map((date, ii) => {
+                const calendarCellStyle = getCalendarCellStyle(date?.toDate(), i)
+                const backgroundColor = calendarCellStyle?.backgroundColor
+                return (
+                  <View key={ii} style={[u['flex-1'], { height: '100%', backgroundColor }]}></View>
+                )
+              })}
+          </View>
           {showWeekNumber ? (
             <View
               style={[
@@ -322,6 +341,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                   },
                   {
                     ...getCalendarCellStyle(date?.toDate(), i),
+                    backgroundColor: undefined,
                   },
                 ]}
                 key={ii}

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -269,27 +269,8 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
             {
               minHeight: minCellHeight,
             },
-            { position: 'relative' },
           ]}
         >
-          <View
-            style={[
-              { position: 'absolute', height: '100%', width: '100%' },
-              theme.isRTL ? u['flex-row-reverse'] : u['flex-row'],
-            ]}
-          >
-            {week
-              .map((d) =>
-                showAdjacentMonths ? targetDate.date(d) : d > 0 ? targetDate.date(d) : null,
-              )
-              .map((date, ii) => {
-                const calendarCellStyle = getCalendarCellStyle(date?.toDate(), i)
-                const backgroundColor = calendarCellStyle?.backgroundColor
-                return (
-                  <View key={ii} style={[u['flex-1'], { height: '100%', backgroundColor }]}></View>
-                )
-              })}
-          </View>
           {showWeekNumber ? (
             <View
               style={[
@@ -341,7 +322,6 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                   },
                   {
                     ...getCalendarCellStyle(date?.toDate(), i),
-                    backgroundColor: undefined,
                   },
                 ]}
                 key={ii}

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -319,6 +319,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
                   u['flex-column'],
                   {
                     minHeight: minCellHeight,
+                    zIndex: ii * -1,
                   },
                   {
                     ...getCalendarCellStyle(date?.toDate(), i),


### PR DESCRIPTION
This is my first PR to this project.
I tried to fix the issue where events are hidden by the background color.

| before | after |
| ------------- | ------------- |
| When a background color is added by cell styling, the second and subsequent days of multi-day events are hidden. | I added a view that only applies background color behind the calendar cells and removed the background color styling from the cells. |
| ![image](https://github.com/user-attachments/assets/f1427b34-d139-4460-92b7-b084ca2e738b) | ![image](https://github.com/user-attachments/assets/1e378d8b-cab5-4a3a-9a62-ea5846af4fce) |




