### PR TITLE
**fix(schedule-month-separator): correct event grouping and sorting**

### DIFF
--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -175,7 +175,7 @@ function _CalendarBody<T extends ICalendarEventBase>({
 
     if (isEventOrderingEnabled) {
       // Events are being sorted once so we dont have to do it on each loop
-      const sortedEvents = events.sort((a, b) => a.start.getTime() - b.start.getTime())
+      const sortedEvents = events.sort((a, b) => a.start.getDate() - b.start.getDate())
       return sortedEvents.map((event) => ({
         ...event,
         overlapPosition: getOrderOfEvent(event, sortedEvents),

--- a/src/components/Schedule.tsx
+++ b/src/components/Schedule.tsx
@@ -119,15 +119,17 @@ function _Schedule<T extends ICalendarEventBase>({
   /**
    * Group by events by start date.
    */
-  const getItem = React.useMemo(() => {
-    const groupedData = events.reduce((result: any, item: T): any => {
-      const startDate = dayjs(item.start).format(SIMPLE_DATE_FORMAT)
-      if (!result[startDate]) {
-        result[startDate] = []
-      }
-      result[startDate].push(item)
-      return result
-    }, {})
+  const getItem = React.useMemo((): T[][] => {
+    const groupedData = events
+      .sort((a, b) => dayjs(a.start).diff(b.start))
+      .reduce((result: any, item: T): any => {
+        const startDate = dayjs(item.start).format(SIMPLE_DATE_FORMAT)
+        if (!result[startDate]) {
+          result[startDate] = []
+        }
+        result[startDate].push(item)
+        return result
+      }, {})
 
     return Object.values(groupedData)
   }, [events])
@@ -149,7 +151,7 @@ function _Schedule<T extends ICalendarEventBase>({
     const date = dayjs(eventGroup[0].start).locale(locale)
     const shouldHighlight = activeDate ? date.isSame(activeDate, 'date') : isToday(date)
     const isNewMonth =
-      index === 0 || !dayjs(eventGroup[0].start).isSame(events[index - 1].start, 'month')
+      index === 0 || !dayjs(eventGroup[0].start).isSame(getItem[index - 1][0].start, 'month')
 
     return (
       <View style={[u['flex'], { padding: 2, flexWrap: 'wrap' }]}>


### PR DESCRIPTION
### Summary of Changes  
**Fixed Event Grouping and Sorting in Schedule View**

**Event Sorting and Grouping Logic Update**:  
The logic for sorting and grouping events in the schedule view has been updated to ensure events are displayed in chronological order and properly grouped by date.  

- **Sorting**: Events are now sorted by their start date before being grouped, ensuring they appear in the correct sequence.
- **Grouping**: Events are grouped by their formatted start date, and the groups are now correctly ordered within the same month.

**New Month Transition Logic**:  
The logic for detecting the start of a new month has been updated to correctly reference the grouped events, ensuring the transition between months is accurate.

**Issue Discovery**:  
I noticed this bug after updating to the latest version from my previous Pull Request #1115 , where events were not sorted correctly, and the grouping within the same month failed to function as expected.

### Impact  
- Events are now consistently grouped by date and sorted in the correct order, providing a more reliable and user-friendly schedule view.  
- The transition between months is now accurately detected, improving the clarity of the schedule layout.

These updates enhance the schedule view’s usability and ensure that events are presented in a logical, easily digestible format.
