### PR TITLE
fix: improved performance speed for getOrderOfEvent and getCountOfEventsAtEvent methods

### DIFF
--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs'
 import * as React from 'react'
-import { useMemo } from 'react'
 import {
   AccessibilityProps,
   Platform,
@@ -164,21 +163,23 @@ function _CalendarBody<T extends ICalendarEventBase>({
     [onLongPressCell],
   )
 
-  const internalEnrichedEventsByDate = useMemo(() => {
+  const internalEnrichedEventsByDate = React.useMemo(() => {
     if (enableEnrichedEvents) {
       return enrichedEventsByDate || enrichEvents(events, eventsAreSorted)
     }
     return {}
   }, [enableEnrichedEvents, enrichedEventsByDate, events, eventsAreSorted])
 
-  const enrichedEvents = useMemo(() => {
+  const enrichedEvents = React.useMemo(() => {
     if (enableEnrichedEvents) return []
 
     if (isEventOrderingEnabled) {
-      return events.map((event) => ({
+      // Events are being sorted once so we dont have to do it on each loop
+      const sortedEvents = events.sort((a, b) => a.start.getTime() - b.start.getTime())
+      return sortedEvents.map((event) => ({
         ...event,
-        overlapPosition: getOrderOfEvent(event, events),
-        overlapCount: getCountOfEventsAtEvent(event, events),
+        overlapPosition: getOrderOfEvent(event, sortedEvents),
+        overlapCount: getCountOfEventsAtEvent(event, sortedEvents),
       }))
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,14 @@ import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import isBetween from 'dayjs/plugin/isBetween'
 import isoWeek from 'dayjs/plugin/isoWeek'
+import minMax from 'dayjs/plugin/minMax'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 
 dayjs.extend(duration)
 dayjs.extend(isBetween)
 dayjs.extend(isoWeek)
+dayjs.extend(minMax)
+dayjs.extend(isSameOrAfter)
 
 export * from './components/Calendar'
 export * from './components/CalendarBody'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,10 @@ import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import isBetween from 'dayjs/plugin/isBetween'
 import isoWeek from 'dayjs/plugin/isoWeek'
-import minMax from 'dayjs/plugin/minMax'
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 
 dayjs.extend(duration)
 dayjs.extend(isBetween)
 dayjs.extend(isoWeek)
-dayjs.extend(minMax)
-dayjs.extend(isSameOrAfter)
 
 export * from './components/Calendar'
 export * from './components/CalendarBody'

--- a/src/utils/__tests__/datetime.test.ts
+++ b/src/utils/__tests__/datetime.test.ts
@@ -1,6 +1,8 @@
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import isBetween from 'dayjs/plugin/isBetween'
+import minMax from 'dayjs/plugin/minMax'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import Mockdate from 'mockdate'
 import * as R from 'remeda'
 
@@ -12,6 +14,8 @@ Mockdate.set('2021-09-17T04:00:00.000Z')
 
 dayjs.extend(isBetween)
 dayjs.extend(duration)
+dayjs.extend(minMax)
+dayjs.extend(isSameOrAfter)
 
 const events: ICalendarEventBase[] = [
   {
@@ -153,13 +157,13 @@ describe('getOrderOfEvent', () => {
   test('3 events middle', () => {
     const event = events[6]
     const index = utils.getOrderOfEvent(event, events)
-    expect(index).toEqual(1)
+    expect(index).toEqual(2)
   })
 
   test('3 events end', () => {
     const event = events[5]
     const index = utils.getOrderOfEvent(event, events)
-    expect(index).toEqual(2)
+    expect(index).toEqual(1)
   })
 })
 

--- a/src/utils/__tests__/datetime.test.ts
+++ b/src/utils/__tests__/datetime.test.ts
@@ -1,8 +1,6 @@
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import isBetween from 'dayjs/plugin/isBetween'
-import minMax from 'dayjs/plugin/minMax'
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import Mockdate from 'mockdate'
 import * as R from 'remeda'
 
@@ -14,8 +12,6 @@ Mockdate.set('2021-09-17T04:00:00.000Z')
 
 dayjs.extend(isBetween)
 dayjs.extend(duration)
-dayjs.extend(minMax)
-dayjs.extend(isSameOrAfter)
 
 const events: ICalendarEventBase[] = [
   {


### PR DESCRIPTION
I used rndemo project in order to understand why modes of `week` `day` and `3days` where very slow when trying to navigate them.
To be able to render 87 events on `week` mode it was taking approx 1260ms
I applied to stress it even further with 500 events which took a bit over a minute 62seconds.

Of course this makes the library almost unusable since in all real life scenarios we will navigate from a screen to this one and that could take some time to render.

After i applied the proposed fixes

- 87 events loaded in just 88 milliseconds
- 500 events loaded in just 430 milliseconds
