### PR TITLE
better margin top implementation for multiday event in month view

### DIFF
--- a/src/components/CalendarEventForMonthView.tsx
+++ b/src/components/CalendarEventForMonthView.tsx
@@ -58,13 +58,12 @@ function _CalendarEventForMonthView<T extends ICalendarEventBase>({
           }
         : {},
       isRTL ? { right: 0 } : { left: 0 },
-      u['mt-2'],
     ],
   })
 
   return (
     <TouchableOpacity
-      style={{ minHeight: eventMinHeightForMonthView }}
+      style={[{ minHeight: eventMinHeightForMonthView }, u['mt-2']]}
       onPress={() => !event.disabled && onPressEvent?.(event)}
     >
       {(!isMultipleDays && date.isSame(event.start, 'day')) ||


### PR DESCRIPTION
Hi,

with the existing margin top implementation for month view events, there are no gaps between multiday event and it doesn't look that nice.
![image](https://github.com/user-attachments/assets/ff824870-919d-4fad-bc50-f42f0bfd4a99)

By moving margin-top implementation to parent view instead of touchableopacity for the event, it looks neater.
![image](https://github.com/user-attachments/assets/6c81f1c3-4f92-4bb8-a153-31976064879d)
