### PR TITLE
fix event render durations when use showAdjacentMonths=false option.

### DIFF
--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -398,7 +398,7 @@ export function getEventSpanningInfo(
   const isMultipleDays = eventDuration > 1
   // This is to determine how many days from the event to show during a week
   const eventWeekDuration =
-    !showAdjacentMonths && monthDaysLeft < 7 && monthDaysLeft < eventDuration
+    !showAdjacentMonths && monthDaysLeft < 7 && monthDaysLeft < eventDaysLeft
       ? monthDaysLeft + 1
       : eventDaysLeft > weekDaysLeft
       ? weekDaysLeft


### PR DESCRIPTION
it's simple problem.

sample storybook code : 
```tsx
import { storiesOf } from '@storybook/react'
import React, { useCallback } from 'react'
import { Button } from 'react-native'

import { Calendar } from '../src'
import dayjs from "dayjs";

const MOBILE_HEIGHT = 736

storiesOf('reproduction-issue-1136', module)
  .add('month mode', () => <CalendarContainer swipeEnabled={true} />)

interface CalendarContainerProps {
  swipeEnabled: boolean
}

const events = [
  {
    title: 'event3',
    start: dayjs("2025-02-13").toDate(),
    end: dayjs("2025-02-23").toDate(),
  },
]

const CalendarContainer: React.FC<CalendarContainerProps> = ({ swipeEnabled }) => {
  return (
    <>
      <Calendar
        events={events}
        swipeEnabled={swipeEnabled}
        date={new Date("2025-02-01")}
        height={MOBILE_HEIGHT}
        mode="month"
        showAdjacentMonths={false}
      />
    </>
  )
}
```

when before fix:
![image](https://github.com/user-attachments/assets/9b36fc94-9e13-4356-8ad7-2d5c62ee6455)

after:
![image](https://github.com/user-attachments/assets/28b03182-4dd2-4e68-8256-5c3964c94b7a)



this is only occur when use showAdjacentMonths=false option.