### PR TITLE
fix monthview/weekview discrepancy when using sortedMonthView and weekStartOn

### DIFF
--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -111,10 +111,10 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
   )
 
   const getStartOfWeek = (date: dayjs.Dayjs) => {
-    if(date.day() < weekStartsOn) {
+    if (date.day() < weekStartsOn) {
       return date.add(weekStartsOn - date.day() - 7, 'days')
     }
-    else if(date.day() > weekStartsOn) {
+    if (date.day() > weekStartsOn) {
       return date.add(weekStartsOn - date.day(), 'days')
     }
     return date
@@ -144,13 +144,11 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
       /**
        * Start of week should consider weekStartOn parameter instead of relying on day.startOf('week') which is locale affected
        */
-      const startOfWeek = getStartOfWeek(day);
+      const startOfWeek = getStartOfWeek(day)
 
       //filter all events that starts from the current week until the current day, and sort them by reverse starting time
       let filteredEvents = events
-        .filter(
-          ({ start, end }) => dayjs(end).isAfter(startOfWeek) && dayjs(start).isBefore(max),
-        )
+        .filter(({ start, end }) => dayjs(end).isAfter(startOfWeek) && dayjs(start).isBefore(max))
         .sort((a, b) => {
           if (dayjs(a.start).isSame(b.start, 'day')) {
             const aDuration = dayjs.duration(dayjs(a.end).diff(dayjs(a.start))).days()
@@ -190,7 +188,10 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
       //optimize sorting of event nodes and make sure that no empty gaps are left on top of calendar cell
       while (!tmpDay.isAfter(day)) {
         for (const event of filteredEvents) {
-          if (dayjs(event.end).isBefore(tmpDay.startOf('day')) || dayjs(event.end).isSame(tmpDay.startOf('day'))) {
+          if (
+            dayjs(event.end).isBefore(tmpDay.startOf('day')) || 
+            dayjs(event.end).isSame(tmpDay.startOf('day'))
+          ) {
             const eventToMoveUp = filteredEvents.find((e) =>
               dayjs(e.start).startOf('day').isSame(tmpDay.startOf('day')),
             )
@@ -216,7 +217,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
 
       return finalEvents
     },
-    [events, sortedMonthView],
+    [events, sortedMonthView, getStartOfWeek],
   )
 
   const renderDateCell = (date: dayjs.Dayjs | null, index: number) => {

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -110,6 +110,16 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
     [calendarCellTextStyle],
   )
 
+  const getStartOfWeek = (date: dayjs.Dayjs) => {
+    if(date.day() < weekStartsOn) {
+      return date.add(weekStartsOn - date.day() - 7, 'days')
+    }
+    else if(date.day() > weekStartsOn) {
+      return date.add(weekStartsOn - date.day(), 'days')
+    }
+    return date
+  }
+
   const sortedEvents = React.useCallback(
     (day: dayjs.Dayjs) => {
       if (!sortedMonthView) {
@@ -131,10 +141,15 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
       let min = day.startOf('day')
       const max = day.endOf('day')
 
+      /**
+       * Start of week should consider weekStartOn parameter instead of relying on day.startOf('week') which is locale affected
+       */
+      const startOfWeek = getStartOfWeek(day);
+
       //filter all events that starts from the current week until the current day, and sort them by reverse starting time
       let filteredEvents = events
         .filter(
-          ({ start, end }) => dayjs(end).isAfter(day.startOf('week')) && dayjs(start).isBefore(max),
+          ({ start, end }) => dayjs(end).isAfter(startOfWeek) && dayjs(start).isBefore(max),
         )
         .sort((a, b) => {
           if (dayjs(a.start).isSame(b.start, 'day')) {
@@ -170,12 +185,12 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
        * For example, when rendering for 03/01, Event 3 should be moved to the top, since there is a gap left by Event 1
        */
       const finalEvents: T[] = []
-      let tmpDay: dayjs.Dayjs = day.startOf('week')
+      let tmpDay: dayjs.Dayjs = startOfWeek
       //re-sort events from the start of week until the calendar cell date
       //optimize sorting of event nodes and make sure that no empty gaps are left on top of calendar cell
       while (!tmpDay.isAfter(day)) {
         for (const event of filteredEvents) {
-          if (dayjs(event.end).isBefore(tmpDay.startOf('day'))) {
+          if (dayjs(event.end).isBefore(tmpDay.startOf('day')) || dayjs(event.end).isSame(tmpDay.startOf('day'))) {
             const eventToMoveUp = filteredEvents.find((e) =>
               dayjs(e.start).startOf('day').isSame(tmpDay.startOf('day')),
             )

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -110,15 +110,18 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
     [calendarCellTextStyle],
   )
 
-  const getStartOfWeek = (date: dayjs.Dayjs) => {
-    if (date.day() < weekStartsOn) {
-      return date.add(weekStartsOn - date.day() - 7, 'days')
-    }
-    if (date.day() > weekStartsOn) {
-      return date.add(weekStartsOn - date.day(), 'days')
-    }
-    return date
-  }
+  const getStartOfWeek = React.useCallback(
+    (date: dayjs.Dayjs) => {
+      if (date.day() < weekStartsOn) {
+        return date.add(weekStartsOn - date.day() - 7, 'days')
+      }
+      if (date.day() > weekStartsOn) {
+        return date.add(weekStartsOn - date.day(), 'days')
+      }
+      return date
+    },
+    [],
+  )
 
   const sortedEvents = React.useCallback(
     (day: dayjs.Dayjs) => {
@@ -189,7 +192,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
       while (!tmpDay.isAfter(day)) {
         for (const event of filteredEvents) {
           if (
-            dayjs(event.end).isBefore(tmpDay.startOf('day')) || 
+            dayjs(event.end).isBefore(tmpDay.startOf('day')) ||
             dayjs(event.end).isSame(tmpDay.startOf('day'))
           ) {
             const eventToMoveUp = filteredEvents.find((e) =>

--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -120,7 +120,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
       }
       return date
     },
-    [],
+    [weekStartsOn],
   )
 
   const sortedEvents = React.useCallback(


### PR DESCRIPTION
Hi @acro5piano 

Found and fixed an issue related visualization discrepancy between month view and week view.

See the following images, in week view on 30th the green node is shown ending on 30th 7AM but in month view it is showing again on 31st.

![image](https://github.com/user-attachments/assets/9d70258f-a9a8-4dd7-a42b-aa3e8d334062)
![image](https://github.com/user-attachments/assets/82c593fb-4bdf-493f-ba2e-341589dfff29)

The root cause is due to the week start date calculation in sortedMonthView logic. 
The previous logic derive startOfWeek based on dayjs.startOf('week') which derive week start date based on device locale. 
This causes problem when the calendar component is configured to have a different week start day using weekStartOn.

The improved logic consider weekStartOn in the week start date calculation.

