### PR TITLE
fix: declare native libraries as peer dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,6 @@
       "dependencies": {
         "calendarize": "^1.1.1",
         "dayjs": "^1.11.13",
-        "react-native-gesture-handler": "^2.22.1",
-        "react-native-infinite-pager": "^0.3.18",
-        "react-native-reanimated": "^3.16.7",
       },
       "devDependencies": {
         "@babel/core": "^7.26.8",
@@ -52,8 +49,11 @@
         "webpack-merge": "^5.10.0",
       },
       "peerDependencies": {
-        "react": "*",
-        "react-native": "*",
+        "react": ">=18.0.0",
+        "react-native": ">=0.65.0",
+        "react-native-gesture-handler": ">=2.2.0",
+        "react-native-infinite-pager": ">=0.3.18",
+        "react-native-reanimated": ">=3.0.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   },
   "dependencies": {
     "calendarize": "^1.1.1",
-    "dayjs": "^1.11.13",
-    "react-native-gesture-handler": "^2.22.1",
-    "react-native-infinite-pager": "^0.3.18",
-    "react-native-reanimated": "^3.16.7"
+    "dayjs": "^1.11.13"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
+    "react": ">=18.0.0",
+    "react-native": ">=0.65.0",
+    "react-native-gesture-handler": ">=2.2.0",
+    "react-native-infinite-pager": ">=0.3.18",
+    "react-native-reanimated": ">=3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.8",


### PR DESCRIPTION
Since we have a clear README to install them along with our libraries, remove them from the dependency list and declare as peer dependencies.