### PR TITLE
Fix issue where spanning events hide other events

### DIFF
--- a/src/components/CalendarBodyForMonthView.tsx
+++ b/src/components/CalendarBodyForMonthView.tsx
@@ -192,6 +192,7 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
          */
         let finalEvents: T[] = []
         let tmpDay: dayjs.Dayjs = startOfWeek
+        let movedEvents: T[] = []
         //re-sort events from the start of week until the calendar cell date
         //optimize sorting of event nodes and make sure that no empty gaps are left on top of calendar cell
         while (!tmpDay.isAfter(day)) {
@@ -205,12 +206,20 @@ function _CalendarBodyForMonthView<T extends ICalendarEventBase>({
               )
               if (eventToMoveUp != undefined) {
                 //remove eventToMoveUp from finalEvents first
-                if (finalEvents.indexOf(eventToMoveUp) > -1) {
+                if (
+                  finalEvents.indexOf(eventToMoveUp) > -1 &&
+                  movedEvents.indexOf(eventToMoveUp) === -1
+                ) {
                   finalEvents.splice(finalEvents.indexOf(eventToMoveUp), 1)
                 }
 
                 if (finalEvents.indexOf(event) > -1) {
-                  finalEvents.splice(finalEvents.indexOf(event), 1, eventToMoveUp)
+                  if (movedEvents.indexOf(eventToMoveUp) === -1) {
+                    finalEvents.splice(finalEvents.indexOf(event), 1, eventToMoveUp)
+                    movedEvents.push(eventToMoveUp)
+                  } else {
+                    finalEvents.splice(finalEvents.indexOf(event), 1)
+                  }
                 } else {
                   finalEvents.push(eventToMoveUp)
                 }

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -109,118 +109,34 @@ export const tonsOfEventsSorted = tonsOfEvents.sort((a, b) => a.start.getTime() 
 
 export const spanningEvents: Array<ICalendarEventBase & { color?: string }> = [
   {
-    title: 'event1',
-    start: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(3, 'day')
-      .set('hour', 9)
-      .set('minute', 0)
-      .toDate(),
-    end: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(4, 'day')
-      .set('hour', 17)
-      .set('minute', 0)
-      .toDate(),
+    title: 'Watch Boxing',
+    start: dayjs().subtract(1, 'week').set('hour', 14).set('minute', 30).toDate(),
+    end: dayjs().subtract(1, 'week').set('hour', 15).set('minute', 30).toDate(),
   },
   {
-    title: 'event2',
-    start: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(4, 'day')
-      .set('hour', 9)
-      .set('minute', 0)
-      .toDate(),
-    end: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(5, 'day')
-      .set('hour', 17)
-      .set('minute', 0)
-      .toDate(),
+    title: 'Laundry',
+    start: dayjs().subtract(1, 'week').set('hour', 1).set('minute', 30).toDate(),
+    end: dayjs().subtract(1, 'week').set('hour', 2).set('minute', 30).toDate(),
   },
   {
-    title: 'event3',
-    start: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(4, 'day')
-      .set('hour', 9)
-      .set('minute', 0)
-      .toDate(),
-    end: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(4, 'day')
-      .set('hour', 17)
-      .set('minute', 0)
-      .toDate(),
+    title: 'Meeting',
+    start: dayjs().subtract(1, 'week').set('hour', 10).set('minute', 0).toDate(),
+    end: dayjs().add(1, 'week').set('hour', 10).set('minute', 30).toDate(),
   },
   {
-    title: 'event4',
-    start: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(5, 'day')
-      .set('hour', 9)
-      .set('minute', 0)
-      .toDate(),
-    end: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(5, 'day')
-      .set('hour', 17)
-      .set('minute', 0)
-      .toDate(),
+    title: 'Coffee break',
+    start: dayjs().set('hour', 14).set('minute', 30).toDate(),
+    end: dayjs().add(1, 'week').set('hour', 15).set('minute', 30).toDate(),
   },
   {
-    title: 'event5',
-    start: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(5, 'day')
-      .set('hour', 9)
-      .set('minute', 0)
-      .toDate(),
-    end: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(5, 'day')
-      .set('hour', 17)
-      .set('minute', 0)
-      .toDate(),
+    title: 'Repair my car',
+    start: dayjs().add(1, 'day').set('hour', 7).set('minute', 45).toDate(),
+    end: dayjs().add(4, 'day').set('hour', 13).set('minute', 30).toDate(),
   },
   {
-    title: 'event6',
-    start: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(5, 'day')
-      .set('hour', 9)
-      .set('minute', 0)
-      .toDate(),
-    end: dayjs()
-      .date(1)
-      .add(1, 'week')
-      .day(5)
-      .add(5, 'day')
-      .set('hour', 17)
-      .set('minute', 0)
-      .toDate(),
+    title: 'Vacation',
+    start: dayjs().subtract(1, 'month').set('hour', 7).set('minute', 45).toDate(),
+    end: dayjs().add(1, 'month').set('hour', 13).set('minute', 30).toDate(),
   },
 ]
 

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -109,34 +109,118 @@ export const tonsOfEventsSorted = tonsOfEvents.sort((a, b) => a.start.getTime() 
 
 export const spanningEvents: Array<ICalendarEventBase & { color?: string }> = [
   {
-    title: 'Watch Boxing',
-    start: dayjs().subtract(1, 'week').set('hour', 14).set('minute', 30).toDate(),
-    end: dayjs().subtract(1, 'week').set('hour', 15).set('minute', 30).toDate(),
+    title: 'event1',
+    start: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(3, 'day')
+      .set('hour', 9)
+      .set('minute', 0)
+      .toDate(),
+    end: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(4, 'day')
+      .set('hour', 17)
+      .set('minute', 0)
+      .toDate(),
   },
   {
-    title: 'Laundry',
-    start: dayjs().subtract(1, 'week').set('hour', 1).set('minute', 30).toDate(),
-    end: dayjs().subtract(1, 'week').set('hour', 2).set('minute', 30).toDate(),
+    title: 'event2',
+    start: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(4, 'day')
+      .set('hour', 9)
+      .set('minute', 0)
+      .toDate(),
+    end: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(5, 'day')
+      .set('hour', 17)
+      .set('minute', 0)
+      .toDate(),
   },
   {
-    title: 'Meeting',
-    start: dayjs().subtract(1, 'week').set('hour', 10).set('minute', 0).toDate(),
-    end: dayjs().add(1, 'week').set('hour', 10).set('minute', 30).toDate(),
+    title: 'event3',
+    start: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(4, 'day')
+      .set('hour', 9)
+      .set('minute', 0)
+      .toDate(),
+    end: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(4, 'day')
+      .set('hour', 17)
+      .set('minute', 0)
+      .toDate(),
   },
   {
-    title: 'Coffee break',
-    start: dayjs().set('hour', 14).set('minute', 30).toDate(),
-    end: dayjs().add(1, 'week').set('hour', 15).set('minute', 30).toDate(),
+    title: 'event4',
+    start: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(5, 'day')
+      .set('hour', 9)
+      .set('minute', 0)
+      .toDate(),
+    end: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(5, 'day')
+      .set('hour', 17)
+      .set('minute', 0)
+      .toDate(),
   },
   {
-    title: 'Repair my car',
-    start: dayjs().add(1, 'day').set('hour', 7).set('minute', 45).toDate(),
-    end: dayjs().add(4, 'day').set('hour', 13).set('minute', 30).toDate(),
+    title: 'event5',
+    start: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(5, 'day')
+      .set('hour', 9)
+      .set('minute', 0)
+      .toDate(),
+    end: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(5, 'day')
+      .set('hour', 17)
+      .set('minute', 0)
+      .toDate(),
   },
   {
-    title: 'Vacation',
-    start: dayjs().subtract(1, 'month').set('hour', 7).set('minute', 45).toDate(),
-    end: dayjs().add(1, 'month').set('hour', 13).set('minute', 30).toDate(),
+    title: 'event6',
+    start: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(5, 'day')
+      .set('hour', 9)
+      .set('minute', 0)
+      .toDate(),
+    end: dayjs()
+      .date(1)
+      .add(1, 'week')
+      .day(5)
+      .add(5, 'day')
+      .set('hour', 17)
+      .set('minute', 0)
+      .toDate(),
   },
 ]
 


### PR DESCRIPTION
I tried to the issue where spanning events hide other events.

| before | after |
| ------------- | ------------- |
| Event6 is not visible because it is covered by Event2. | Event6 is visible. |
| ![image](https://github.com/user-attachments/assets/90beee85-202e-4862-a7d0-fd5e85a145f7) | ![image](https://github.com/user-attachments/assets/da4d6813-6b5d-436e-9d31-df60c50b7b34) |




