### PR TITLE
Fix event move up behavior

### DIFF
--- a/stories/desktop.stories.tsx
+++ b/stories/desktop.stories.tsx
@@ -7,7 +7,13 @@ import { Alert, Dimensions, View } from 'react-native'
 
 import { Calendar, ICalendarEventBase } from '../src'
 import { CONTROL_HEIGHT, Control } from './components/Control'
-import { customEventRenderer, events, spanningEvents, customHourRenderer } from './events'
+import {
+  customEventRenderer,
+  events,
+  spanningEvents,
+  customHourRenderer,
+  complexSpanningEvents,
+} from './events'
 import { useEvents } from './hooks'
 import { styles } from './styles'
 import { themes } from './themes'
@@ -135,6 +141,37 @@ storiesOf('showcase - Desktop', module)
           onPressEvent={(event) => alert(event.title)}
           onPressCell={state.addEvent}
           showAdjacentMonths={false}
+        />
+      </View>
+    )
+  })
+  .add('Month mode - Spanning Events (complex)', () => {
+    const state = useEvents(complexSpanningEvents)
+    return (
+      <View style={styles.desktop}>
+        <Calendar
+          mode="month"
+          height={SCREEN_HEIGHT}
+          events={state.events}
+          onPressEvent={(event) => alert(event.title)}
+          onPressCell={state.addEvent}
+          maxVisibleEventCount={6}
+        />
+      </View>
+    )
+  })
+  .add('Month mode - Spanning Events (complex) RTL', () => {
+    const state = useEvents(complexSpanningEvents)
+    return (
+      <View style={styles.desktop}>
+        <Calendar
+          mode="month"
+          height={SCREEN_HEIGHT}
+          isRTL
+          events={state.events}
+          onPressEvent={(event) => alert(event.title)}
+          onPressCell={state.addEvent}
+          maxVisibleEventCount={6}
         />
       </View>
     )

--- a/stories/events.tsx
+++ b/stories/events.tsx
@@ -140,6 +140,74 @@ export const spanningEvents: Array<ICalendarEventBase & { color?: string }> = [
   },
 ]
 
+export const complexSpanningEvents: Array<ICalendarEventBase & { color?: string }> = [
+  {
+    title: 'event1-1',
+    start: dayjs().date(1).add(1, 'week').day(5).add(3, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(4, 'day').toDate(),
+  },
+  {
+    title: 'event1-2',
+    start: dayjs().date(1).add(1, 'week').day(5).add(3, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(4, 'day').toDate(),
+  },
+  {
+    title: 'event1-3',
+    start: dayjs().date(1).add(1, 'week').day(5).add(3, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(4, 'day').toDate(),
+  },
+  {
+    title: 'event2',
+    start: dayjs().date(1).add(1, 'week').day(5).add(4, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(8, 'day').toDate(),
+  },
+  {
+    title: 'event3',
+    start: dayjs().date(1).add(1, 'week').day(5).add(4, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(6, 'day').toDate(),
+  },
+  {
+    title: 'event4-1',
+    start: dayjs().date(1).add(1, 'week').day(5).add(5, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(5, 'day').toDate(),
+  },
+  {
+    title: 'event4-2',
+    start: dayjs().date(1).add(1, 'week').day(5).add(5, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(5, 'day').toDate(),
+  },
+  {
+    title: 'event5-1',
+    start: dayjs().date(1).add(1, 'week').day(5).add(6, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(6, 'day').toDate(),
+  },
+  {
+    title: 'event5-2',
+    start: dayjs().date(1).add(1, 'week').day(5).add(6, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(6, 'day').toDate(),
+  },
+  {
+    title: 'event6-1',
+    start: dayjs().date(1).add(1, 'week').day(5).add(7, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(7, 'day').toDate(),
+  },
+  {
+    title: 'event6-2',
+    start: dayjs().date(1).add(1, 'week').day(5).add(7, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(7, 'day').toDate(),
+  },
+  {
+    title: 'event6-3',
+    start: dayjs().date(1).add(1, 'week').day(5).add(7, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(7, 'day').toDate(),
+  },
+  {
+    title: 'event7',
+    start: dayjs().date(1).add(1, 'week').day(5).add(8, 'day').toDate(),
+    end: dayjs().date(1).add(1, 'week').day(5).add(8, 'day').toDate(),
+  },
+]
+
 export interface MyCustomEventType extends ICalendarEventBase {
   color?: string
 }


### PR DESCRIPTION
Sorry, the fix I made in PR #1181 still contained the issues in cases with complex combinations of spanning events.
- Some events were hidden
- Some events were displayed multiple times
- Some events were not moved up even though there was space available

This PR resolves the above issues.

### Before Screenshot
- `event4-1` and `event5-1` are not visible because they are covered by `event2`.
- `event6-3` is displayed three times.
- There is space available in the first row of Friday and Saturday.

### After Screenshot
- `event4-1` and `event5-1` are now visible.
- `event6-3` is displayed only once.
- Events are correctly moved up when space is available.


| before | after |
| ------------- | ------------- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/68148436-aa85-4b09-94b3-7d9c683c8220" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/3df00e68-76a6-479d-9792-e4f8ca2844af" /> |