### PR TITLE
Use react-native-gesture-handler ScrollView in CalendarBody

### DIFF
--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -3,12 +3,13 @@ import * as React from 'react'
 import {
   type AccessibilityProps,
   Platform,
-  ScrollView,
   StyleSheet,
   type TextStyle,
   View,
   type ViewStyle,
 } from 'react-native'
+
+import { ScrollView } from 'react-native-gesture-handler'
 
 import { u } from '../commonStyles'
 import { useNow } from '../hooks/useNow'

--- a/src/components/CalendarBody.tsx
+++ b/src/components/CalendarBody.tsx
@@ -8,9 +8,7 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
-
 import { ScrollView } from 'react-native-gesture-handler'
-
 import { u } from '../commonStyles'
 import { useNow } from '../hooks/useNow'
 import type {


### PR DESCRIPTION
Fixes an issue https://github.com/acro5piano/react-native-big-calendar/issues/1178 where scrolling of CalendarBody would not work inside InfinitePager on Android

Credit for fix is to @berkozturk97 as per his comment on the issue

Related issue from the pager library:
https://github.com/computerjazz/react-native-infinite-pager/issues/18