### PR TITLE
Fix: resolve scroll conflicts with parent ScrollView

### DIFF
--- a/src/hooks/usePanResponder.ts
+++ b/src/hooks/usePanResponder.ts
@@ -17,7 +17,10 @@ export function usePanResponder({
       PanResponder.create({
         // see https://stackoverflow.com/questions/47568850/touchableopacity-with-parent-panresponder
         onMoveShouldSetPanResponder: (_, { dx, dy }) => {
-          return dx > 2 || dx < -2 || dy > 2 || dy < -2
+          if (onSwipeHorizontal !== undefined) {
+            return Math.abs(dx / dy) > 1
+          }
+          return false
         },
         onPanResponderMove: (_, { dy, dx }) => {
           if (dy < -1 * SWIPE_THRESHOLD || SWIPE_THRESHOLD < dy || panHandledRef.current) {


### PR DESCRIPTION
## Description
I wrapped the Calendar component with ScrollView to enable vertical scrolling for large monthly calendars.
On iOS, I encountered an issue where vertical scrolling did not work correctly.
This PR resolves that issue.

## Problem
In the `onMoveShouldSetPanResponder` of `PanResponder.create`, when the absolute value of `dy` was greater than 2, it returned `true`. This caused the function to return `true` in most cases when swiping vertically, interfering with the vertical scroll operations of the wrapping ScrollView.

## Solution
To resolve this problem, I modified the logic to return `true` only when the absolute value of `dx / dy` is greater than 1 (when the horizontal movement of the swipe is greater than the vertical movement).
Additionally, this calculation is now only applied when `onSwipeHorizontal` exists.